### PR TITLE
Add object storage + CDN module with signed URLs (Issue #27)

### DIFF
--- a/CONTENT_POLICY.md
+++ b/CONTENT_POLICY.md
@@ -1,0 +1,166 @@
+# Content Policy
+
+**Last Updated:** October 2, 2025
+
+## Overview
+
+GIFDistributor is committed to maintaining a **safe-for-work (SFW) platform** for all users. All content uploaded to our platform is subject to automated scanning and manual review to ensure compliance with our content policy.
+
+## What's Allowed
+
+✅ **Safe-for-Work Content**
+- Family-friendly animations and GIFs
+- Educational and informational content
+- Professional presentations and demonstrations
+- Funny, entertaining, and creative content appropriate for all audiences
+- Product demonstrations and marketing materials
+- News and current events content
+- Sports highlights and gameplay clips
+- Nature, animals, and wildlife content
+- Art, music, and cultural content
+
+## What's Not Allowed
+
+❌ **Prohibited Content**
+
+### Adult/NSFW Content
+- Sexually explicit material or nudity
+- Suggestive or pornographic content
+- Content intended for mature audiences only
+- Dating or hookup content
+
+### Violence & Harm
+- Graphic violence or gore
+- Content depicting serious injury or death
+- Self-harm or suicide content
+- Animal cruelty or abuse
+
+### Hate Speech & Harassment
+- Hateful content targeting individuals or groups
+- Harassment, bullying, or threats
+- Discriminatory content based on race, religion, gender, sexual orientation, disability, or other protected characteristics
+- Symbols or imagery associated with hate groups
+
+### Illegal Content
+- Content that violates local, national, or international laws
+- Promotion of illegal activities
+- Copyright infringement or pirated content
+- Sale or promotion of illegal goods or services
+
+### Spam & Deceptive Content
+- Spam, scams, or phishing attempts
+- Misleading or deceptive content
+- Manipulated media intended to deceive (deepfakes)
+- Malware or malicious content
+
+## Content Moderation Process
+
+### Automated Scanning
+
+All uploaded content undergoes automated scanning:
+
+1. **Metadata Analysis**: Titles, tags, and descriptions are scanned for policy violations
+2. **Visual Content Analysis**: AI-powered scanning detects inappropriate imagery
+3. **Confidence Scoring**: Each scan produces a confidence score (0-100%)
+
+### Moderation Decisions
+
+Based on scan results, content receives one of three decisions:
+
+- **✅ Approved** (High confidence - safe): Content is immediately available
+- **❌ Rejected** (High confidence - violation): Content is blocked and not published
+- **⚠️ Flagged** (Low confidence - uncertain): Content is queued for manual human review
+
+### Manual Review
+
+Content flagged as uncertain is reviewed by human moderators who:
+- Examine the full context of the content
+- Apply policy guidelines consistently
+- Make final approval or rejection decisions
+- Document their reasoning for compliance and appeals
+
+### Review Thresholds
+
+- **Auto-approve threshold**: 95% confidence (configurable)
+- **Auto-reject threshold**: 80% confidence (configurable)
+- **Strict mode**: Available for enhanced filtering
+
+## Your Responsibilities
+
+As a content creator on GIFDistributor, you agree to:
+
+1. **Only upload SFW content** that complies with this policy
+2. **Provide accurate metadata** (titles, tags, descriptions)
+3. **Respect intellectual property rights** and only upload content you own or have permission to use
+4. **Report policy violations** if you encounter prohibited content
+5. **Accept moderation decisions** made by our automated systems and moderators
+
+## Enforcement
+
+### Violations
+
+Violations of this content policy may result in:
+
+1. **First violation**: Content removal + warning
+2. **Repeated violations**: Temporary account suspension (7-30 days)
+3. **Severe or persistent violations**: Permanent account termination
+4. **Illegal content**: Report to appropriate authorities + immediate termination
+
+### Appeals Process
+
+If you believe your content was incorrectly rejected:
+
+1. **Review our policy**: Ensure your content complies with all guidelines
+2. **Submit an appeal**: Contact moderation@gifdist.io with:
+   - Asset ID or scan ID
+   - Explanation of why the content is SFW-compliant
+   - Any additional context
+3. **Wait for review**: Appeals are typically reviewed within 2-3 business days
+4. **Final decision**: Human moderator will make a final determination
+
+Appeals for content containing clear violations will not be considered.
+
+## Audit & Compliance
+
+### Transparency
+
+- All moderation decisions are logged in our audit trail
+- Statistics on approval rates, rejection rates, and flag rates are tracked
+- Compliance reports are available for regulatory purposes
+
+### Data Retention
+
+- Audit logs are retained for **3 years** minimum for compliance
+- Rejected content metadata is retained (content itself is not stored)
+- Appeal records are maintained for historical reference
+
+### Third-Party Services
+
+Our automated scanning may use services from:
+- AWS Rekognition
+- Google Cloud Vision AI
+- Azure Content Moderator
+- OpenAI Moderation API
+
+These services process your content according to their respective privacy policies.
+
+## Questions & Support
+
+- **Policy questions**: policy@gifdist.io
+- **Content appeals**: moderation@gifdist.io
+- **General support**: support@gifdist.io
+
+## Policy Updates
+
+We may update this policy as needed. Material changes will be announced via:
+- Email notification to all users
+- Banner notice on the platform
+- Updated "Last Updated" date at the top of this document
+
+Continued use of the platform after policy updates constitutes acceptance of the updated policy.
+
+---
+
+**Remember**: When in doubt, don't upload it. If you're unsure whether content is SFW-appropriate, it's better to err on the side of caution.
+
+Thank you for helping us maintain a safe and welcoming platform for everyone!

--- a/MODERATION_FAQ.md
+++ b/MODERATION_FAQ.md
@@ -1,0 +1,198 @@
+# Moderation FAQ
+
+## Frequently Asked Questions about Content Moderation
+
+### General Questions
+
+#### Q: Why does GIFDistributor moderate content?
+**A:** We moderate to ensure all content is safe-for-work (SFW) and appropriate for all audiences. This protects users, maintains platform quality, and ensures compliance with legal requirements.
+
+#### Q: Is all content reviewed by humans?
+**A:** No. Most content (95%+) is automatically approved or rejected by AI. Only uncertain cases are flagged for human review.
+
+#### Q: How long does moderation take?
+**A:**
+- **Automated approval/rejection**: Instant (< 1 second)
+- **Manual review**: 24-48 hours typically
+- **Peak times**: May take up to 72 hours
+
+---
+
+### Upload Process
+
+#### Q: What triggers an automatic rejection?
+**A:** High-confidence detection of:
+- NSFW/adult content
+- Graphic violence
+- Hate speech keywords
+- Known spam patterns
+- Copyright violations
+
+#### Q: What causes content to be flagged?
+**A:** Low confidence in automated classification, such as:
+- Ambiguous imagery
+- Context-dependent content
+- Borderline cases
+- New/unusual content types
+
+#### Q: Can I see why my content was rejected?
+**A:** Yes! The rejection notice includes:
+- Decision category (NSFW, violence, etc.)
+- Confidence score
+- Specific reasons when available
+- Scan ID for appeals
+
+---
+
+### Appeals & Reviews
+
+#### Q: How do I appeal a rejection?
+**A:** Email moderation@gifdist.io with:
+1. Your scan ID or asset ID
+2. Explanation of why content is SFW
+3. Any relevant context
+
+Appeals are reviewed within 2-3 business days.
+
+#### Q: What if I disagree with a manual review?
+**A:** Manual reviews by human moderators are considered final. However, you can submit additional context if you believe there was a misunderstanding.
+
+#### Q: Can I reupload rejected content?
+**A:** No. Uploading the same content that was rejected may result in account penalties. If you believe the rejection was in error, file an appeal instead.
+
+---
+
+### Technical Questions
+
+#### Q: What AI services do you use?
+**A:** We may use any combination of:
+- AWS Rekognition
+- Google Cloud Vision AI
+- Azure Content Moderator
+- OpenAI Moderation API
+
+The specific service used may vary.
+
+#### Q: Is my content shared with these services?
+**A:** Yes, for scanning purposes only. These services process content according to their privacy policies and do not retain it permanently.
+
+#### Q: What happens to rejected content?
+**A:**
+- **Files**: Deleted immediately after rejection
+- **Metadata**: Retained for audit purposes (30 days)
+- **Audit logs**: Retained for compliance (3 years)
+
+---
+
+### Privacy & Security
+
+#### Q: Who can see my flagged content during manual review?
+**A:** Only authorized human moderators. Reviews are confidential and logged for compliance.
+
+#### Q: Do you keep a history of my uploads?
+**A:**
+- **Approved content**: Yes, as long as you keep it published
+- **Rejected content**: Metadata only, files deleted
+- **All decisions**: Logged in audit trail for compliance
+
+#### Q: Can I delete my moderation history?
+**A:** You can delete published content at any time. Audit logs are retained for compliance but are not publicly visible.
+
+---
+
+### Best Practices
+
+#### Q: How can I avoid rejections?
+**A:**
+1. Only upload family-friendly content
+2. Use clear, accurate titles and tags
+3. Avoid suggestive language or imagery
+4. Review our [Content Policy](./CONTENT_POLICY.md) before uploading
+5. When in doubt, don't upload it
+
+#### Q: What makes for good metadata?
+**A:**
+- **Specific**: "Golden retriever catching frisbee" vs "Funny video"
+- **Accurate**: Tags match the actual content
+- **Professional**: Avoid excessive punctuation, ALL CAPS, or clickbait
+- **Relevant**: Description adds context
+
+#### Q: Can I appeal multiple times?
+**A:** You can appeal once per rejected upload. Repeated appeals for the same content without new information may not be reviewed.
+
+---
+
+### Account & Enforcement
+
+#### Q: What happens if I upload prohibited content?
+**A:**
+- **First time**: Content removed + warning
+- **Repeated violations**: Temporary suspension (7-30 days)
+- **Severe violations**: Permanent ban
+- **Illegal content**: Reported to authorities
+
+#### Q: How do I know if I have a warning?
+**A:** You'll receive an email notification. Warnings are also visible in your account dashboard.
+
+#### Q: Can I get my account back after a ban?
+**A:**
+- **Temporary bans**: Automatic restoration after period
+- **Permanent bans**: May appeal to moderation@gifdist.io with explanation
+- **Illegal content bans**: No appeals
+
+---
+
+### Platform Improvements
+
+#### Q: How can I help improve moderation accuracy?
+**A:**
+1. Provide detailed, accurate metadata
+2. Report false positives/negatives
+3. Participate in feedback surveys
+4. Suggest policy improvements
+
+#### Q: Does the AI get better over time?
+**A:** Yes! Our systems learn from:
+- Manual review decisions
+- User feedback
+- False positive/negative reports
+- New content patterns
+
+#### Q: Can I opt out of automated scanning?
+**A:** No. All content must pass moderation before publication. This is required for platform integrity.
+
+---
+
+### Special Cases
+
+#### Q: What about artistic nudity or medical content?
+**A:** Our platform is strictly SFW. Even artistic, educational, or medical content containing nudity is not permitted. Consider specialized platforms for this content.
+
+#### Q: What about violence in news/journalism?
+**A:** Newsworthy content is evaluated on a case-by-case basis. Graphic violence is prohibited even in news context. Use discretion and expect manual review.
+
+#### Q: Can I upload content from social media/other platforms?
+**A:** Only if:
+1. You own the content or have explicit permission
+2. Content is SFW and policy-compliant
+3. Content doesn't violate the original platform's terms
+
+---
+
+### Getting Help
+
+#### Q: Where can I get more information?
+**A:**
+- [Content Policy](./CONTENT_POLICY.md) - Full guidelines
+- [User Notice](./USER_NOTICE.md) - Upload process
+- [Contact Support](mailto:support@gifdist.io) - Technical help
+
+#### Q: I have a question not answered here?
+**A:** Contact us:
+- **Policy questions**: policy@gifdist.io
+- **Moderation appeals**: moderation@gifdist.io
+- **Technical support**: support@gifdist.io
+
+---
+
+*Last updated: October 2, 2025*

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ print(f"Short link CTR: {short_link_metrics['ctr']}%")
 Run the test suite:
 
 ```bash
-pytest test_sharelinks.py test_analytics.py test_integration.py
+pytest test_sharelinks.py test_analytics.py test_cdn.py test_integration.py
 ```
 
 Or run all tests at once:
@@ -201,6 +201,28 @@ pytest
 
 **EventType**: `VIEW`, `PLAY`, `CLICK`
 **Platform**: `WEB`, `SLACK`, `DISCORD`, `TEAMS`, `TWITTER`, `FACEBOOK`, `OTHER`
+
+### CDNHelper
+
+- `get_asset_headers(content_type, content_length, is_immutable=False, cache_duration=CachePolicy.LONG_CACHE, range_header=None)`: Get complete headers for asset delivery (returns headers, range_spec, status_code)
+- `create_signed_asset_url(asset_url, expiration_seconds=3600)`: Create a signed URL for secure asset access
+- `validate_asset_url(url)`: Validate a signed asset URL (returns is_valid, error_message)
+
+### CachePolicy
+
+- `get_headers(cache_duration=LONG_CACHE, is_immutable=False, is_private=False)`: Generate cache control headers
+- Cache duration constants: `IMMUTABLE_CACHE` (1 year), `LONG_CACHE` (24 hours), `SHORT_CACHE` (1 hour), `NO_CACHE` (0)
+
+### RangeRequest
+
+- `parse_range_header(range_header, content_length)`: Parse HTTP Range header and return (start, end) bytes
+- `get_range_response_headers(start, end, total_length, content_type)`: Generate headers for partial content response
+- `get_full_response_headers(total_length, content_type)`: Generate headers for full content response
+
+### SignedURL
+
+- `generate_signed_url(base_url, expiration_seconds=3600, additional_params=None)`: Generate signed URL with expiration
+- `validate_signed_url(url)`: Validate signature and expiration (returns is_valid, error_message)
 
 ### Utility Functions
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,126 @@
 # GIFDistributor
+
+A system for distributing and sharing GIF assets with short links and canonical URLs.
+
+## Features
+
+- **Share Links**: Generate short, shareable links for GIF assets (`/s/{short_code}`)
+- **Canonical URLs**: Persistent asset URLs (`/a/{asset_id}`)
+- **Analytics Tracking**: Track views, plays, clicks, and CTR across platforms
+- **Platform Metrics**: Break down engagement by platform (Slack, Discord, Teams, Twitter, etc.)
+- **Deduplication**: Hash-based asset ID generation to avoid duplicate uploads
+- **Metadata Support**: Open Graph tags for social media sharing
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Basic Example
+
+```python
+from sharelinks import ShareLinkGenerator, create_asset_hash
+
+# Initialize the generator
+generator = ShareLinkGenerator(base_url="https://gifdist.io")
+
+# Create a share link for an asset
+link_info = generator.create_share_link(
+    asset_id="abc123def456",
+    title="Funny Cat GIF",
+    tags=["cat", "funny", "pets"]
+)
+
+print(f"Short URL: {link_info['short_url']}")
+print(f"Canonical URL: {link_info['canonical_url']}")
+```
+
+### Hash-Based Asset IDs
+
+```python
+# Generate hash-based ID for deduplication
+file_hash = create_asset_hash("path/to/gif.gif")
+asset_id = generator.generate_hash_based_id(file_hash)
+```
+
+### Resolving Short Links
+
+```python
+# Resolve a short code to get asset information
+asset_info = generator.resolve_short_link("Ab12Cd34")
+if asset_info:
+    print(f"Asset ID: {asset_info['asset_id']}")
+    print(f"Clicks: {asset_info['clicks']}")
+```
+
+### Analytics Tracking
+
+```python
+from analytics import AnalyticsTracker, EventType, Platform
+
+# Initialize the analytics tracker
+tracker = AnalyticsTracker()
+
+# Track events
+tracker.track_event(
+    asset_id="abc123def456",
+    event_type=EventType.VIEW,
+    platform=Platform.SLACK,
+    short_code="Ab12Cd34"
+)
+
+tracker.track_event(
+    asset_id="abc123def456",
+    event_type=EventType.PLAY,
+    platform=Platform.SLACK,
+    short_code="Ab12Cd34"
+)
+
+# Get asset metrics
+metrics = tracker.get_asset_metrics("abc123def456")
+print(f"Views: {metrics['views']}")
+print(f"Plays: {metrics['plays']}")
+print(f"CTR: {metrics['ctr']}%")
+
+# Get platform-specific metrics
+platform_metrics = tracker.get_platform_metrics("abc123def456")
+print(f"Slack metrics: {platform_metrics['slack']}")
+
+# Get top performing assets
+top_assets = tracker.get_top_assets(metric="ctr", limit=5)
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+pytest test_sharelinks.py test_analytics.py
+```
+
+## API Reference
+
+### ShareLinkGenerator
+
+- `create_canonical_url(asset_id, asset_type="gif")`: Create canonical asset URL
+- `create_share_link(asset_id, title="", tags=None)`: Generate short share link
+- `resolve_short_link(short_code)`: Resolve short code to asset info
+- `generate_hash_based_id(content_hash)`: Create deterministic asset ID
+- `get_share_metadata(short_code)`: Get Open Graph metadata
+
+### AnalyticsTracker
+
+- `track_event(asset_id, event_type, platform, short_code, metadata)`: Track analytics event
+- `get_asset_metrics(asset_id)`: Get aggregated metrics (views, plays, clicks, CTR)
+- `get_platform_metrics(asset_id)`: Get metrics broken down by platform
+- `get_short_link_metrics(short_code)`: Get metrics for a specific short link
+- `get_top_assets(metric, limit)`: Get top performing assets by metric
+- `get_events_by_timeframe(asset_id, start_time, end_time)`: Get events within timeframe
+- `clear_events(asset_id)`: Clear events for an asset or all events
+
+### Utility Functions
+
+- `create_asset_hash(file_path)`: Generate SHA-256 hash of asset file

--- a/USER_NOTICE.md
+++ b/USER_NOTICE.md
@@ -1,0 +1,134 @@
+# User Notice: Content Moderation
+
+## 📢 Important: SFW-Only Platform
+
+GIFDistributor is a **safe-for-work (SFW) platform**. All content is automatically scanned before publication.
+
+---
+
+## 🤖 What Happens When You Upload
+
+### 1. Automated Scanning
+Your content is immediately scanned by AI-powered moderation:
+- ✅ **Metadata Check**: Title, tags, and description analyzed
+- ✅ **Visual Analysis**: Image/video content scanned for policy violations
+- ✅ **Confidence Score**: Accuracy rating for the moderation decision
+
+### 2. Instant Decision
+
+Your upload receives one of three outcomes:
+
+#### ✅ **Approved**
+- Your content passed all checks
+- Published immediately and available for sharing
+- High confidence (>95%) that content is SFW
+
+#### ❌ **Rejected**
+- Policy violation detected
+- Content not published
+- **Why?** Common reasons:
+  - NSFW or adult content
+  - Violent or graphic imagery
+  - Hate speech or harassment
+  - Spam or misleading content
+
+➡️ [Review our Content Policy](./CONTENT_POLICY.md) for details
+
+#### ⚠️ **Flagged for Review**
+- Uncertain classification
+- Queued for human moderator review
+- Usually reviewed within 24-48 hours
+- You'll receive an email when reviewed
+
+---
+
+## 📋 Quick Guidelines
+
+### ✅ DO Upload
+- Family-friendly animations
+- Funny, creative, entertaining content
+- Professional presentations
+- Educational material
+- Product demos
+- News and current events
+- Sports highlights
+- Nature and animals
+
+### ❌ DON'T Upload
+- Adult or sexually explicit content
+- Graphic violence or gore
+- Hateful or discriminatory content
+- Illegal or copyright-infringing content
+- Spam or deceptive material
+
+---
+
+## ⚡ Best Practices
+
+### For Faster Approval
+
+1. **Use clear, descriptive titles**
+   - Good: "Cat playing with yarn ball"
+   - Avoid: "OMG you won't believe this!!!"
+
+2. **Add relevant tags**
+   - Helps our AI understand your content
+   - Use specific, accurate tags
+   - Example: ["cat", "funny", "pets"]
+
+3. **Write a brief description**
+   - Provides context for moderation
+   - Helps users discover your content
+
+4. **Avoid borderline content**
+   - When in doubt, don't upload it
+   - Err on the side of caution
+
+---
+
+## 🔍 Privacy & Data
+
+### What We Scan
+- Uploaded files (images/videos)
+- Titles, tags, and descriptions
+- File metadata
+
+### How We Scan
+- **Automated AI services** (AWS Rekognition, Google Vision, etc.)
+- **Human moderators** for flagged content only
+- **Audit trail** for all decisions (compliance & transparency)
+
+### What We Store
+- Approved content and metadata
+- Moderation decisions and audit logs
+- Rejected content metadata only (files are deleted)
+
+---
+
+## 📞 Questions?
+
+### Need Help?
+- **Policy questions**: policy@gifdist.io
+- **Appeal a decision**: moderation@gifdist.io
+- **Technical support**: support@gifdist.io
+
+### Read More
+- [Full Content Policy](./CONTENT_POLICY.md) - Complete guidelines
+- [Moderation FAQ](./MODERATION_FAQ.md) - Common questions
+- [Privacy Policy](#) - How we handle your data
+
+---
+
+## ⚖️ Your Responsibility
+
+By uploading content, you confirm that:
+- ✓ Content is safe-for-work (SFW)
+- ✓ You own the rights or have permission to upload
+- ✓ Content complies with our [Content Policy](./CONTENT_POLICY.md)
+- ✓ Metadata (title/tags/description) is accurate
+
+---
+
+**Thank you for helping us maintain a safe and welcoming platform for everyone!** 🎉
+
+*Last updated: October 2, 2025*

--- a/analytics.py
+++ b/analytics.py
@@ -1,0 +1,264 @@
+"""
+Analytics Module for GIF Distributor
+Tracks views, plays, CTR by platform
+Issue: #33
+"""
+from typing import Dict, List, Optional
+from datetime import datetime
+from collections import defaultdict
+from enum import Enum
+
+
+class EventType(Enum):
+    """Types of analytics events"""
+    VIEW = "view"  # Link was viewed (page loaded)
+    PLAY = "play"  # Media was played
+    CLICK = "click"  # Link was clicked through
+
+
+class Platform(Enum):
+    """Platforms where content can be shared"""
+    WEB = "web"
+    SLACK = "slack"
+    DISCORD = "discord"
+    TEAMS = "teams"
+    TWITTER = "twitter"
+    FACEBOOK = "facebook"
+    OTHER = "other"
+
+
+class AnalyticsTracker:
+    """Tracks analytics events for assets and share links"""
+
+    def __init__(self):
+        self._events: List[Dict] = []
+        self._metrics_cache: Dict[str, Dict] = {}
+
+    def track_event(
+        self,
+        asset_id: str,
+        event_type: EventType,
+        platform: Platform = Platform.WEB,
+        short_code: Optional[str] = None,
+        metadata: Optional[Dict] = None
+    ) -> Dict:
+        """
+        Track an analytics event
+
+        Args:
+            asset_id: The asset being tracked
+            event_type: Type of event (view, play, click)
+            platform: Platform where event occurred
+            short_code: Optional short code if from share link
+            metadata: Optional additional metadata
+
+        Returns:
+            The created event record
+        """
+        event = {
+            "asset_id": asset_id,
+            "event_type": event_type.value,
+            "platform": platform.value,
+            "short_code": short_code,
+            "timestamp": datetime.utcnow().isoformat(),
+            "metadata": metadata or {}
+        }
+        self._events.append(event)
+
+        # Invalidate cache for this asset
+        if asset_id in self._metrics_cache:
+            del self._metrics_cache[asset_id]
+
+        return event
+
+    def get_asset_metrics(self, asset_id: str) -> Dict:
+        """
+        Get aggregated metrics for an asset
+
+        Args:
+            asset_id: The asset to get metrics for
+
+        Returns:
+            Dictionary with views, plays, clicks, and CTR
+        """
+        # Check cache
+        if asset_id in self._metrics_cache:
+            return self._metrics_cache[asset_id]
+
+        asset_events = [e for e in self._events if e["asset_id"] == asset_id]
+
+        views = sum(1 for e in asset_events if e["event_type"] == EventType.VIEW.value)
+        plays = sum(1 for e in asset_events if e["event_type"] == EventType.PLAY.value)
+        clicks = sum(1 for e in asset_events if e["event_type"] == EventType.CLICK.value)
+
+        # Calculate CTR (Click-Through Rate): clicks / views
+        ctr = (clicks / views * 100) if views > 0 else 0.0
+
+        # Play rate: plays / views
+        play_rate = (plays / views * 100) if views > 0 else 0.0
+
+        metrics = {
+            "asset_id": asset_id,
+            "views": views,
+            "plays": plays,
+            "clicks": clicks,
+            "ctr": round(ctr, 2),
+            "play_rate": round(play_rate, 2),
+            "total_events": len(asset_events)
+        }
+
+        # Cache the result
+        self._metrics_cache[asset_id] = metrics
+        return metrics
+
+    def get_platform_metrics(self, asset_id: str) -> Dict[str, Dict]:
+        """
+        Get metrics broken down by platform
+
+        Args:
+            asset_id: The asset to get platform metrics for
+
+        Returns:
+            Dictionary mapping platform names to their metrics
+        """
+        asset_events = [e for e in self._events if e["asset_id"] == asset_id]
+
+        platform_data = defaultdict(lambda: {"views": 0, "plays": 0, "clicks": 0})
+
+        for event in asset_events:
+            platform = event["platform"]
+            event_type = event["event_type"]
+
+            if event_type == EventType.VIEW.value:
+                platform_data[platform]["views"] += 1
+            elif event_type == EventType.PLAY.value:
+                platform_data[platform]["plays"] += 1
+            elif event_type == EventType.CLICK.value:
+                platform_data[platform]["clicks"] += 1
+
+        # Calculate CTR for each platform
+        result = {}
+        for platform, data in platform_data.items():
+            views = data["views"]
+            clicks = data["clicks"]
+            plays = data["plays"]
+
+            result[platform] = {
+                "views": views,
+                "plays": plays,
+                "clicks": clicks,
+                "ctr": round((clicks / views * 100) if views > 0 else 0.0, 2),
+                "play_rate": round((plays / views * 100) if views > 0 else 0.0, 2)
+            }
+
+        return result
+
+    def get_short_link_metrics(self, short_code: str) -> Dict:
+        """
+        Get metrics for a specific short link
+
+        Args:
+            short_code: The short code to get metrics for
+
+        Returns:
+            Dictionary with metrics for this short link
+        """
+        link_events = [e for e in self._events if e.get("short_code") == short_code]
+
+        if not link_events:
+            return {
+                "short_code": short_code,
+                "views": 0,
+                "plays": 0,
+                "clicks": 0,
+                "ctr": 0.0,
+                "play_rate": 0.0
+            }
+
+        views = sum(1 for e in link_events if e["event_type"] == EventType.VIEW.value)
+        plays = sum(1 for e in link_events if e["event_type"] == EventType.PLAY.value)
+        clicks = sum(1 for e in link_events if e["event_type"] == EventType.CLICK.value)
+
+        return {
+            "short_code": short_code,
+            "asset_id": link_events[0]["asset_id"],
+            "views": views,
+            "plays": plays,
+            "clicks": clicks,
+            "ctr": round((clicks / views * 100) if views > 0 else 0.0, 2),
+            "play_rate": round((plays / views * 100) if views > 0 else 0.0, 2)
+        }
+
+    def get_top_assets(self, metric: str = "views", limit: int = 10) -> List[Dict]:
+        """
+        Get top performing assets by a specific metric
+
+        Args:
+            metric: Metric to sort by (views, plays, clicks, ctr)
+            limit: Maximum number of results
+
+        Returns:
+            List of assets with their metrics, sorted by the specified metric
+        """
+        # Get unique asset IDs
+        asset_ids = set(e["asset_id"] for e in self._events)
+
+        # Get metrics for each asset
+        asset_metrics = [self.get_asset_metrics(aid) for aid in asset_ids]
+
+        # Sort by the specified metric
+        sorted_assets = sorted(
+            asset_metrics,
+            key=lambda x: x.get(metric, 0),
+            reverse=True
+        )
+
+        return sorted_assets[:limit]
+
+    def get_events_by_timeframe(
+        self,
+        asset_id: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None
+    ) -> List[Dict]:
+        """
+        Get events for an asset within a timeframe
+
+        Args:
+            asset_id: The asset to get events for
+            start_time: Start of timeframe (inclusive)
+            end_time: End of timeframe (inclusive)
+
+        Returns:
+            List of events within the timeframe
+        """
+        asset_events = [e for e in self._events if e["asset_id"] == asset_id]
+
+        if start_time:
+            asset_events = [
+                e for e in asset_events
+                if datetime.fromisoformat(e["timestamp"]) >= start_time
+            ]
+
+        if end_time:
+            asset_events = [
+                e for e in asset_events
+                if datetime.fromisoformat(e["timestamp"]) <= end_time
+            ]
+
+        return asset_events
+
+    def clear_events(self, asset_id: Optional[str] = None):
+        """
+        Clear events, optionally for a specific asset
+
+        Args:
+            asset_id: If provided, only clear events for this asset
+        """
+        if asset_id:
+            self._events = [e for e in self._events if e["asset_id"] != asset_id]
+            if asset_id in self._metrics_cache:
+                del self._metrics_cache[asset_id]
+        else:
+            self._events.clear()
+            self._metrics_cache.clear()

--- a/cdn.py
+++ b/cdn.py
@@ -1,0 +1,416 @@
+"""
+CDN Module for GIF Distributor
+Provides cache headers, Range support, and signed URLs
+Issue: #34
+"""
+from typing import Dict, Optional, Tuple
+from datetime import datetime, timedelta
+import hashlib
+import hmac
+import base64
+from urllib.parse import urlencode, urlparse, parse_qs
+
+
+class CachePolicy:
+    """Cache control policies for different content types"""
+
+    # Cache durations in seconds
+    IMMUTABLE_CACHE = 31536000  # 1 year for immutable assets
+    LONG_CACHE = 86400  # 24 hours for stable content
+    SHORT_CACHE = 3600  # 1 hour for dynamic content
+    NO_CACHE = 0  # No caching
+
+    @staticmethod
+    def get_headers(
+        cache_duration: int = LONG_CACHE,
+        is_immutable: bool = False,
+        is_private: bool = False
+    ) -> Dict[str, str]:
+        """
+        Generate cache control headers
+
+        Args:
+            cache_duration: Cache duration in seconds
+            is_immutable: Whether the content is immutable
+            is_private: Whether the content should only be cached by browsers (not CDN)
+
+        Returns:
+            Dictionary of cache-related headers
+        """
+        if cache_duration == 0:
+            return {
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0"
+            }
+
+        cache_control_parts = []
+
+        if is_private:
+            cache_control_parts.append("private")
+        else:
+            cache_control_parts.append("public")
+
+        cache_control_parts.append(f"max-age={cache_duration}")
+
+        if is_immutable:
+            cache_control_parts.append("immutable")
+
+        headers = {
+            "Cache-Control": ", ".join(cache_control_parts)
+        }
+
+        # Add Expires header for HTTP/1.0 compatibility
+        expires_time = datetime.utcnow() + timedelta(seconds=cache_duration)
+        headers["Expires"] = expires_time.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        return headers
+
+
+class RangeRequest:
+    """Handles HTTP Range requests for partial content delivery"""
+
+    @staticmethod
+    def parse_range_header(
+        range_header: str,
+        content_length: int
+    ) -> Optional[Tuple[int, int]]:
+        """
+        Parse HTTP Range header
+
+        Args:
+            range_header: The Range header value (e.g., "bytes=0-1023")
+            content_length: Total content length in bytes
+
+        Returns:
+            Tuple of (start, end) byte positions, or None if invalid
+        """
+        if not range_header or not range_header.startswith("bytes="):
+            return None
+
+        try:
+            range_spec = range_header[6:]  # Remove "bytes="
+
+            # Handle single range only (not multipart ranges)
+            if "," in range_spec:
+                range_spec = range_spec.split(",")[0]
+
+            if "-" not in range_spec:
+                return None
+
+            start_str, end_str = range_spec.split("-", 1)
+
+            # Handle different range formats
+            if not start_str and not end_str:
+                return None
+            elif not start_str:
+                # Suffix range: last N bytes (e.g., "-500")
+                suffix_length = int(end_str)
+                start = max(0, content_length - suffix_length)
+                end = content_length - 1
+            elif not end_str:
+                # Range from start to end (e.g., "100-")
+                start = int(start_str)
+                end = content_length - 1
+            else:
+                # Full range (e.g., "100-200")
+                start = int(start_str)
+                end = int(end_str)
+
+            # Validate range
+            if start < 0 or end >= content_length or start > end:
+                return None
+
+            return (start, end)
+
+        except (ValueError, IndexError):
+            return None
+
+    @staticmethod
+    def get_range_response_headers(
+        start: int,
+        end: int,
+        total_length: int,
+        content_type: str = "application/octet-stream"
+    ) -> Dict[str, str]:
+        """
+        Generate headers for a range response
+
+        Args:
+            start: Start byte position
+            end: End byte position (inclusive)
+            total_length: Total content length
+            content_type: MIME type of the content
+
+        Returns:
+            Dictionary of response headers
+        """
+        return {
+            "Content-Type": content_type,
+            "Content-Length": str(end - start + 1),
+            "Content-Range": f"bytes {start}-{end}/{total_length}",
+            "Accept-Ranges": "bytes"
+        }
+
+    @staticmethod
+    def get_full_response_headers(
+        total_length: int,
+        content_type: str = "application/octet-stream"
+    ) -> Dict[str, str]:
+        """
+        Generate headers for a full content response
+
+        Args:
+            total_length: Total content length
+            content_type: MIME type of the content
+
+        Returns:
+            Dictionary of response headers
+        """
+        return {
+            "Content-Type": content_type,
+            "Content-Length": str(total_length),
+            "Accept-Ranges": "bytes"
+        }
+
+
+class SignedURL:
+    """Generates and validates signed URLs for secure content delivery"""
+
+    def __init__(self, secret_key: str):
+        """
+        Initialize with a secret key
+
+        Args:
+            secret_key: Secret key for signing URLs
+        """
+        if not secret_key:
+            raise ValueError("Secret key cannot be empty")
+        self.secret_key = secret_key.encode() if isinstance(secret_key, str) else secret_key
+
+    def generate_signed_url(
+        self,
+        base_url: str,
+        expiration_seconds: int = 3600,
+        additional_params: Optional[Dict[str, str]] = None
+    ) -> str:
+        """
+        Generate a signed URL with expiration
+
+        Args:
+            base_url: The base URL to sign
+            expiration_seconds: Seconds until the URL expires
+            additional_params: Additional query parameters to include
+
+        Returns:
+            Signed URL string
+        """
+        # Calculate expiration timestamp
+        expires = int((datetime.utcnow() + timedelta(seconds=expiration_seconds)).timestamp())
+
+        # Parse URL to get path and existing params
+        parsed = urlparse(base_url)
+        params = parse_qs(parsed.query)
+
+        # Flatten params (parse_qs returns lists)
+        flat_params = {k: v[0] if isinstance(v, list) else v for k, v in params.items()}
+
+        # Add expiration
+        flat_params["expires"] = str(expires)
+
+        # Add any additional parameters
+        if additional_params:
+            flat_params.update(additional_params)
+
+        # Create signature payload (path + sorted params)
+        payload = parsed.path + "?" + urlencode(sorted(flat_params.items()))
+
+        # Generate signature
+        signature = hmac.new(
+            self.secret_key,
+            payload.encode(),
+            hashlib.sha256
+        ).digest()
+
+        # Base64 encode and make URL-safe
+        signature_b64 = base64.urlsafe_b64encode(signature).decode().rstrip("=")
+
+        # Add signature to params
+        flat_params["signature"] = signature_b64
+
+        # Construct final URL
+        signed_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}?{urlencode(flat_params)}"
+
+        return signed_url
+
+    def validate_signed_url(self, url: str) -> Tuple[bool, Optional[str]]:
+        """
+        Validate a signed URL
+
+        Args:
+            url: The signed URL to validate
+
+        Returns:
+            Tuple of (is_valid, error_message)
+            If valid: (True, None)
+            If invalid: (False, error_message)
+        """
+        try:
+            parsed = urlparse(url)
+            params = parse_qs(parsed.query)
+
+            # Flatten params
+            flat_params = {k: v[0] if isinstance(v, list) else v for k, v in params.items()}
+
+            # Check for required fields
+            if "expires" not in flat_params:
+                return False, "Missing expiration parameter"
+
+            if "signature" not in flat_params:
+                return False, "Missing signature parameter"
+
+            # Extract and remove signature
+            provided_signature = flat_params.pop("signature")
+
+            # Check expiration
+            expires = int(flat_params["expires"])
+            now = int(datetime.utcnow().timestamp())
+
+            if now >= expires:
+                return False, "URL has expired"
+
+            # Recreate payload
+            payload = parsed.path + "?" + urlencode(sorted(flat_params.items()))
+
+            # Generate expected signature
+            expected_signature = hmac.new(
+                self.secret_key,
+                payload.encode(),
+                hashlib.sha256
+            ).digest()
+
+            expected_signature_b64 = base64.urlsafe_b64encode(expected_signature).decode().rstrip("=")
+
+            # Compare signatures (constant time comparison)
+            if not hmac.compare_digest(provided_signature, expected_signature_b64):
+                return False, "Invalid signature"
+
+            return True, None
+
+        except (ValueError, KeyError) as e:
+            return False, f"Invalid URL format: {str(e)}"
+
+
+class CDNHelper:
+    """Unified helper for CDN-related functionality"""
+
+    def __init__(self, secret_key: Optional[str] = None):
+        """
+        Initialize CDN helper
+
+        Args:
+            secret_key: Secret key for signed URLs (optional)
+        """
+        self.signed_url_handler = SignedURL(secret_key) if secret_key else None
+
+    def get_asset_headers(
+        self,
+        content_type: str,
+        content_length: int,
+        is_immutable: bool = False,
+        cache_duration: int = CachePolicy.LONG_CACHE,
+        range_header: Optional[str] = None
+    ) -> Tuple[Dict[str, str], Optional[Tuple[int, int]], int]:
+        """
+        Get complete headers for asset delivery
+
+        Args:
+            content_type: MIME type of content
+            content_length: Total content length
+            is_immutable: Whether content is immutable
+            cache_duration: Cache duration in seconds
+            range_header: HTTP Range header if present
+
+        Returns:
+            Tuple of (headers, range_spec, status_code)
+            - headers: Complete response headers
+            - range_spec: (start, end) if range request, else None
+            - status_code: 200 or 206 (partial content)
+        """
+        headers = {}
+        range_spec = None
+        status_code = 200
+
+        # Add cache headers
+        cache_headers = CachePolicy.get_headers(
+            cache_duration=cache_duration,
+            is_immutable=is_immutable
+        )
+        headers.update(cache_headers)
+
+        # Handle range requests
+        if range_header:
+            range_spec = RangeRequest.parse_range_header(range_header, content_length)
+
+            if range_spec:
+                start, end = range_spec
+                range_headers = RangeRequest.get_range_response_headers(
+                    start, end, content_length, content_type
+                )
+                headers.update(range_headers)
+                status_code = 206  # Partial Content
+            else:
+                # Invalid range, return full content
+                full_headers = RangeRequest.get_full_response_headers(
+                    content_length, content_type
+                )
+                headers.update(full_headers)
+        else:
+            # No range request
+            full_headers = RangeRequest.get_full_response_headers(
+                content_length, content_type
+            )
+            headers.update(full_headers)
+
+        return headers, range_spec, status_code
+
+    def create_signed_asset_url(
+        self,
+        asset_url: str,
+        expiration_seconds: int = 3600
+    ) -> str:
+        """
+        Create a signed URL for an asset
+
+        Args:
+            asset_url: The asset URL to sign
+            expiration_seconds: Seconds until expiration
+
+        Returns:
+            Signed URL
+
+        Raises:
+            ValueError: If signed URL handler is not configured
+        """
+        if not self.signed_url_handler:
+            raise ValueError("Signed URL handler not configured. Provide secret_key during initialization.")
+
+        return self.signed_url_handler.generate_signed_url(asset_url, expiration_seconds)
+
+    def validate_asset_url(self, url: str) -> Tuple[bool, Optional[str]]:
+        """
+        Validate a signed asset URL
+
+        Args:
+            url: The URL to validate
+
+        Returns:
+            Tuple of (is_valid, error_message)
+
+        Raises:
+            ValueError: If signed URL handler is not configured
+        """
+        if not self.signed_url_handler:
+            raise ValueError("Signed URL handler not configured. Provide secret_key during initialization.")
+
+        return self.signed_url_handler.validate_signed_url(url)

--- a/components/UploadNotice.css
+++ b/components/UploadNotice.css
@@ -1,0 +1,419 @@
+/**
+ * UploadNotice Component Styles
+ * Issue: #31
+ */
+
+/* Upload Notice Container */
+.upload-notice {
+  background: #ffffff;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 600px;
+  margin: 20px auto;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.upload-notice--compact {
+  padding: 12px 16px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  margin: 16px 0;
+}
+
+/* Header */
+.upload-notice__header {
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.upload-notice__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+/* Body */
+.upload-notice__body {
+  margin-bottom: 24px;
+}
+
+.upload-notice__section {
+  margin-bottom: 20px;
+}
+
+.upload-notice__section h4 {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.upload-notice__section p {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.upload-notice__section ul {
+  margin: 8px 0;
+  padding-left: 24px;
+}
+
+.upload-notice__section li {
+  margin: 4px 0;
+  font-size: 14px;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.upload-notice__section--highlight {
+  background: #fef3c7;
+  border-left: 4px solid #f59e0b;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.upload-notice__section--highlight h4 {
+  color: #92400e;
+}
+
+/* Links */
+.upload-notice__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 16px 0;
+  padding: 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+.upload-notice__link {
+  color: #2563eb;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.upload-notice__link:hover {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+/* Acknowledgment */
+.upload-notice__acknowledgment {
+  margin: 20px 0;
+  padding: 16px;
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 8px;
+}
+
+.upload-notice__checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #1f2937;
+  line-height: 1.5;
+}
+
+.upload-notice__checkbox {
+  margin-top: 4px;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.upload-notice__checkbox-label a {
+  color: #2563eb;
+  font-weight: 500;
+}
+
+/* Footer */
+.upload-notice__footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.upload-notice__button {
+  padding: 12px 24px;
+  font-size: 16px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.upload-notice__button--primary {
+  background: #2563eb;
+  color: white;
+}
+
+.upload-notice__button--primary:hover:not(:disabled) {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px rgba(37, 99, 235, 0.25);
+}
+
+.upload-notice__button--primary:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.upload-notice__button--secondary {
+  background: transparent;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+}
+
+.upload-notice__button--secondary:hover {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
+/* Compact Version */
+.upload-notice--compact .upload-notice__content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.upload-notice__icon {
+  font-size: 20px;
+}
+
+.upload-notice__text {
+  margin: 0;
+  font-size: 14px;
+  color: #4b5563;
+}
+
+.upload-notice__text a {
+  color: #2563eb;
+  font-weight: 500;
+}
+
+/* Moderation Result Container */
+.moderation-result {
+  background: #ffffff;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 600px;
+  margin: 20px auto;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.moderation-result--approved {
+  border-color: #10b981;
+  background: linear-gradient(to bottom, #ffffff, #f0fdf4);
+}
+
+.moderation-result--rejected {
+  border-color: #ef4444;
+  background: linear-gradient(to bottom, #ffffff, #fef2f2);
+}
+
+.moderation-result--flagged {
+  border-color: #f59e0b;
+  background: linear-gradient(to bottom, #ffffff, #fffbeb);
+}
+
+/* Header */
+.moderation-result__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.moderation-result__icon {
+  font-size: 32px;
+}
+
+.moderation-result__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+/* Body */
+.moderation-result__body {
+  margin-bottom: 20px;
+}
+
+.moderation-result__message {
+  font-size: 16px;
+  color: #374151;
+  margin: 0 0 16px 0;
+  line-height: 1.6;
+}
+
+.moderation-result__detail {
+  margin: 8px 0;
+  font-size: 14px;
+  color: #4b5563;
+}
+
+.moderation-result__detail strong {
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.moderation-result__reasons {
+  margin: 16px 0;
+  padding: 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+.moderation-result__reasons strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.moderation-result__reasons ul {
+  margin: 0;
+  padding-left: 24px;
+}
+
+.moderation-result__reasons li {
+  margin: 4px 0;
+  font-size: 14px;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.moderation-result__meta {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.moderation-result__meta small {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.moderation-result__help {
+  margin-top: 20px;
+  padding: 16px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+}
+
+.moderation-result__help p {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  color: #1e40af;
+}
+
+.moderation-result__help ul {
+  margin: 8px 0 0 0;
+  padding-left: 24px;
+}
+
+.moderation-result__help li {
+  margin: 4px 0;
+  font-size: 14px;
+  color: #1e40af;
+}
+
+.moderation-result__help a {
+  color: #2563eb;
+  font-weight: 500;
+}
+
+/* Footer */
+.moderation-result__footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.moderation-result__button {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.moderation-result__button--appeal {
+  background: #f59e0b;
+  color: white;
+}
+
+.moderation-result__button--appeal:hover {
+  background: #d97706;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 6px rgba(245, 158, 11, 0.25);
+}
+
+.moderation-result__button--dismiss {
+  background: #6b7280;
+  color: white;
+}
+
+.moderation-result__button--dismiss:hover {
+  background: #4b5563;
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .upload-notice,
+  .moderation-result {
+    padding: 16px;
+    margin: 12px;
+  }
+
+  .upload-notice__title,
+  .moderation-result__title {
+    font-size: 20px;
+  }
+
+  .upload-notice__links {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .upload-notice__footer,
+  .moderation-result__footer {
+    flex-direction: column;
+  }
+
+  .upload-notice__button,
+  .moderation-result__button {
+    width: 100%;
+  }
+
+  .moderation-result__meta {
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/components/UploadNotice.tsx
+++ b/components/UploadNotice.tsx
@@ -1,0 +1,320 @@
+/**
+ * UploadNotice Component
+ * Displays SFW policy notice during upload flow
+ * Issue: #31
+ */
+
+import React, { useState } from 'react';
+
+interface UploadNoticeProps {
+  onAccept: () => void;
+  onDecline?: () => void;
+  compact?: boolean;
+}
+
+export const UploadNotice: React.FC<UploadNoticeProps> = ({
+  onAccept,
+  onDecline,
+  compact = false
+}) => {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  const handleAccept = () => {
+    if (acknowledged) {
+      onAccept();
+    }
+  };
+
+  if (compact) {
+    return (
+      <div className="upload-notice upload-notice--compact">
+        <div className="upload-notice__content">
+          <span className="upload-notice__icon">ℹ️</span>
+          <p className="upload-notice__text">
+            All content is automatically scanned. Only SFW content is allowed.{' '}
+            <a href="/content-policy" target="_blank" rel="noopener noreferrer">
+              View Policy
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="upload-notice">
+      <div className="upload-notice__header">
+        <h3 className="upload-notice__title">
+          📢 Before You Upload
+        </h3>
+      </div>
+
+      <div className="upload-notice__body">
+        <div className="upload-notice__section">
+          <h4>🤖 Automated Scanning</h4>
+          <p>
+            Your content will be automatically scanned using AI-powered moderation:
+          </p>
+          <ul>
+            <li>Metadata analysis (title, tags, description)</li>
+            <li>Visual content scanning</li>
+            <li>Instant decision in most cases</li>
+          </ul>
+        </div>
+
+        <div className="upload-notice__section">
+          <h4>✅ Three Possible Outcomes</h4>
+          <ul>
+            <li>
+              <strong>Approved:</strong> Published immediately
+            </li>
+            <li>
+              <strong>Rejected:</strong> Policy violation detected
+            </li>
+            <li>
+              <strong>Flagged:</strong> Queued for manual review (24-48hrs)
+            </li>
+          </ul>
+        </div>
+
+        <div className="upload-notice__section upload-notice__section--highlight">
+          <h4>⚠️ SFW-Only Platform</h4>
+          <p>
+            <strong>GIFDistributor is strictly safe-for-work.</strong> Do not upload:
+          </p>
+          <ul>
+            <li>Adult or NSFW content</li>
+            <li>Graphic violence or gore</li>
+            <li>Hate speech or harassment</li>
+            <li>Illegal or copyright-infringing content</li>
+          </ul>
+        </div>
+
+        <div className="upload-notice__links">
+          <a
+            href="/content-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="upload-notice__link"
+          >
+            📋 Full Content Policy
+          </a>
+          <a
+            href="/moderation-faq"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="upload-notice__link"
+          >
+            ❓ Moderation FAQ
+          </a>
+          <a
+            href="/user-notice"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="upload-notice__link"
+          >
+            📖 User Guide
+          </a>
+        </div>
+
+        <div className="upload-notice__acknowledgment">
+          <label className="upload-notice__checkbox-label">
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              className="upload-notice__checkbox"
+            />
+            <span>
+              I confirm my content is safe-for-work and complies with the{' '}
+              <a href="/content-policy" target="_blank" rel="noopener noreferrer">
+                Content Policy
+              </a>
+            </span>
+          </label>
+        </div>
+      </div>
+
+      <div className="upload-notice__footer">
+        <button
+          onClick={handleAccept}
+          disabled={!acknowledged}
+          className="upload-notice__button upload-notice__button--primary"
+        >
+          Continue Upload
+        </button>
+        {onDecline && (
+          <button
+            onClick={onDecline}
+            className="upload-notice__button upload-notice__button--secondary"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * ModerationResult Component
+ * Displays the result of automated moderation
+ */
+
+export interface ModerationResultData {
+  decision: 'approved' | 'rejected' | 'flagged';
+  category?: string;
+  confidence: number;
+  reasons: string[];
+  scanId: string;
+  timestamp: string;
+}
+
+interface ModerationResultProps {
+  result: ModerationResultData;
+  onAppeal?: (scanId: string) => void;
+  onDismiss?: () => void;
+}
+
+export const ModerationResult: React.FC<ModerationResultProps> = ({
+  result,
+  onAppeal,
+  onDismiss
+}) => {
+  const getIcon = () => {
+    switch (result.decision) {
+      case 'approved':
+        return '✅';
+      case 'rejected':
+        return '❌';
+      case 'flagged':
+        return '⚠️';
+      default:
+        return 'ℹ️';
+    }
+  };
+
+  const getTitle = () => {
+    switch (result.decision) {
+      case 'approved':
+        return 'Content Approved';
+      case 'rejected':
+        return 'Content Rejected';
+      case 'flagged':
+        return 'Flagged for Review';
+      default:
+        return 'Moderation Result';
+    }
+  };
+
+  const getMessage = () => {
+    switch (result.decision) {
+      case 'approved':
+        return 'Your content passed all moderation checks and is now published!';
+      case 'rejected':
+        return 'Your content violates our SFW policy and cannot be published.';
+      case 'flagged':
+        return 'Your content has been flagged for manual review. You\'ll receive an email when a decision is made (usually within 24-48 hours).';
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <div className={`moderation-result moderation-result--${result.decision}`}>
+      <div className="moderation-result__header">
+        <span className="moderation-result__icon">{getIcon()}</span>
+        <h3 className="moderation-result__title">{getTitle()}</h3>
+      </div>
+
+      <div className="moderation-result__body">
+        <p className="moderation-result__message">{getMessage()}</p>
+
+        {result.category && (
+          <div className="moderation-result__detail">
+            <strong>Category:</strong> {result.category}
+          </div>
+        )}
+
+        <div className="moderation-result__detail">
+          <strong>Confidence:</strong> {(result.confidence * 100).toFixed(0)}%
+        </div>
+
+        {result.reasons.length > 0 && (
+          <div className="moderation-result__reasons">
+            <strong>Reasons:</strong>
+            <ul>
+              {result.reasons.map((reason, index) => (
+                <li key={index}>{reason}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="moderation-result__meta">
+          <small>Scan ID: {result.scanId}</small>
+          <small>Time: {new Date(result.timestamp).toLocaleString()}</small>
+        </div>
+
+        {result.decision === 'rejected' && (
+          <div className="moderation-result__help">
+            <p>
+              <strong>What to do next:</strong>
+            </p>
+            <ul>
+              <li>Review our <a href="/content-policy">Content Policy</a></li>
+              <li>Ensure your content is safe-for-work</li>
+              <li>If you believe this is an error, you may appeal this decision</li>
+            </ul>
+          </div>
+        )}
+
+        {result.decision === 'flagged' && (
+          <div className="moderation-result__help">
+            <p>
+              Our AI couldn't confidently classify your content. A human moderator will review it shortly.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="moderation-result__footer">
+        {result.decision === 'rejected' && onAppeal && (
+          <button
+            onClick={() => onAppeal(result.scanId)}
+            className="moderation-result__button moderation-result__button--appeal"
+          >
+            Appeal Decision
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="moderation-result__button moderation-result__button--dismiss"
+          >
+            {result.decision === 'approved' ? 'Continue' : 'Close'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Usage Example:
+ *
+ * import { UploadNotice, ModerationResult } from './components/UploadNotice';
+ *
+ * // During upload flow
+ * <UploadNotice
+ *   onAccept={() => proceedWithUpload()}
+ *   onDecline={() => cancelUpload()}
+ * />
+ *
+ * // After moderation
+ * <ModerationResult
+ *   result={moderationResult}
+ *   onAppeal={(scanId) => handleAppeal(scanId)}
+ *   onDismiss={() => closeModal()}
+ * />
+ */

--- a/moderation.py
+++ b/moderation.py
@@ -1,0 +1,516 @@
+"""
+SFW-only Moderation Pipeline & Audit
+Provides content moderation with automated scanning and audit trail
+Issue: #25
+"""
+import time
+import hashlib
+from typing import Dict, List, Optional, Tuple
+from enum import Enum
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+class ModerationDecision(Enum):
+    """Moderation decision outcomes"""
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    FLAGGED = "flagged"  # Requires manual review
+    PENDING = "pending"
+
+
+class ContentCategory(Enum):
+    """Content classification categories"""
+    SAFE = "safe"
+    NSFW = "nsfw"
+    GRAPHIC_VIOLENCE = "graphic_violence"
+    HATE_SPEECH = "hate_speech"
+    ILLEGAL = "illegal"
+    SPAM = "spam"
+    UNKNOWN = "unknown"
+
+
+class ModerationError(Exception):
+    """Exception raised when moderation fails"""
+    pass
+
+
+@dataclass
+class ModerationResult:
+    """Result of content moderation"""
+    decision: ModerationDecision
+    category: ContentCategory
+    confidence: float  # 0.0 to 1.0
+    reasons: List[str] = field(default_factory=list)
+    scan_id: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    metadata: Dict = field(default_factory=dict)
+
+
+@dataclass
+class AuditEntry:
+    """Audit trail entry for moderation actions"""
+    audit_id: str
+    asset_id: str
+    decision: ModerationDecision
+    category: ContentCategory
+    confidence: float
+    moderator: str  # "automated" or user ID
+    timestamp: str
+    reasons: List[str]
+    metadata: Dict = field(default_factory=dict)
+
+
+class ContentScanner:
+    """Simulated content scanner (would integrate with real AI/ML service)"""
+
+    def __init__(self, strict_mode: bool = True):
+        """
+        Initialize content scanner
+
+        Args:
+            strict_mode: If True, flag borderline content for review
+        """
+        self.strict_mode = strict_mode
+        # Simulated keyword blocklist
+        self.nsfw_keywords = {
+            "explicit", "nude", "adult", "xxx", "porn", "sex",
+            "nsfw", "18+", "mature"
+        }
+        self.violence_keywords = {
+            "gore", "blood", "violence", "brutal", "graphic"
+        }
+        self.hate_keywords = {
+            "hate", "slur", "racist", "nazi", "supremacist"
+        }
+
+    def scan_metadata(
+        self,
+        title: str = "",
+        tags: Optional[List[str]] = None,
+        description: str = ""
+    ) -> Tuple[ContentCategory, float, List[str]]:
+        """
+        Scan text metadata for inappropriate content
+
+        Args:
+            title: Asset title
+            tags: Asset tags
+            description: Asset description
+
+        Returns:
+            Tuple of (category, confidence, reasons)
+        """
+        tags = tags or []
+        reasons = []
+
+        # Combine all text for scanning
+        text = f"{title} {description} {' '.join(tags)}".lower()
+
+        # Check for NSFW content
+        for keyword in self.nsfw_keywords:
+            if keyword in text:
+                reasons.append(f"NSFW keyword detected: '{keyword}'")
+                return ContentCategory.NSFW, 0.95, reasons
+
+        # Check for violence
+        for keyword in self.violence_keywords:
+            if keyword in text:
+                reasons.append(f"Violence keyword detected: '{keyword}'")
+                return ContentCategory.GRAPHIC_VIOLENCE, 0.90, reasons
+
+        # Check for hate speech
+        for keyword in self.hate_keywords:
+            if keyword in text:
+                reasons.append(f"Hate speech keyword detected: '{keyword}'")
+                return ContentCategory.HATE_SPEECH, 0.95, reasons
+
+        return ContentCategory.SAFE, 0.99, ["No policy violations detected"]
+
+    def scan_visual_content(
+        self,
+        file_path: str,
+        file_hash: str
+    ) -> Tuple[ContentCategory, float, List[str]]:
+        """
+        Scan visual content (simulated - would use AI/ML service)
+
+        Args:
+            file_path: Path to content file
+            file_hash: Hash of file content
+
+        Returns:
+            Tuple of (category, confidence, reasons)
+        """
+        # Simulate visual AI scanning
+        # In production, this would call services like:
+        # - AWS Rekognition
+        # - Google Cloud Vision AI
+        # - Azure Content Moderator
+        # - OpenAI Moderation API
+
+        # For simulation, use hash to deterministically classify
+        # Convert hash to integer (handle non-hex characters)
+        try:
+            hash_int = int(file_hash[:8], 16)
+        except ValueError:
+            # Fall back to sum of character codes for non-hex hashes
+            hash_int = sum(ord(c) for c in file_hash[:8])
+
+        # 95% of content is safe in simulation
+        if hash_int % 100 < 95:
+            return (
+                ContentCategory.SAFE,
+                0.98,
+                ["Visual content analysis passed"]
+            )
+
+        # 3% is flagged for review
+        if hash_int % 100 < 98:
+            return (
+                ContentCategory.UNKNOWN,
+                0.60,
+                ["Low confidence - requires manual review"]
+            )
+
+        # 2% is rejected
+        return (
+            ContentCategory.NSFW,
+            0.85,
+            ["Visual content detected inappropriate imagery"]
+        )
+
+
+class ModerationPipeline:
+    """Main moderation pipeline for content approval"""
+
+    def __init__(
+        self,
+        strict_mode: bool = True,
+        auto_approve_threshold: float = 0.95,
+        auto_reject_threshold: float = 0.80,
+        enable_audit: bool = True
+    ):
+        """
+        Initialize moderation pipeline
+
+        Args:
+            strict_mode: Enable strict content filtering
+            auto_approve_threshold: Confidence threshold for auto-approval
+            auto_reject_threshold: Confidence threshold for auto-rejection
+            enable_audit: Enable audit trail logging
+        """
+        self.scanner = ContentScanner(strict_mode=strict_mode)
+        self.strict_mode = strict_mode
+        self.auto_approve_threshold = auto_approve_threshold
+        self.auto_reject_threshold = auto_reject_threshold
+        self.enable_audit = enable_audit
+
+        # Audit trail storage
+        self._audit_trail: List[AuditEntry] = []
+
+        # Statistics
+        self._stats = {
+            "total_scans": 0,
+            "approved": 0,
+            "rejected": 0,
+            "flagged": 0,
+            "pending": 0
+        }
+
+    def _generate_scan_id(self, asset_id: str) -> str:
+        """Generate unique scan ID"""
+        timestamp = str(time.time())
+        data = f"{asset_id}{timestamp}".encode()
+        return hashlib.sha256(data).hexdigest()[:16]
+
+    def _generate_audit_id(self, scan_id: str) -> str:
+        """Generate unique audit ID"""
+        timestamp = str(time.time())
+        data = f"{scan_id}{timestamp}".encode()
+        return hashlib.sha256(data).hexdigest()[:16]
+
+    def moderate_content(
+        self,
+        asset_id: str,
+        file_path: str,
+        file_hash: str,
+        title: str = "",
+        tags: Optional[List[str]] = None,
+        description: str = "",
+        metadata: Optional[Dict] = None
+    ) -> ModerationResult:
+        """
+        Moderate content through complete pipeline
+
+        Args:
+            asset_id: Unique asset identifier
+            file_path: Path to content file
+            file_hash: Hash of file content
+            title: Asset title
+            tags: Asset tags
+            description: Asset description
+            metadata: Additional metadata
+
+        Returns:
+            ModerationResult with decision and details
+        """
+        self._stats["total_scans"] += 1
+        scan_id = self._generate_scan_id(asset_id)
+        metadata = metadata or {}
+
+        # Step 1: Scan metadata
+        meta_category, meta_confidence, meta_reasons = self.scanner.scan_metadata(
+            title=title,
+            tags=tags,
+            description=description
+        )
+
+        # Early rejection if metadata fails
+        if meta_category != ContentCategory.SAFE:
+            result = ModerationResult(
+                decision=ModerationDecision.REJECTED,
+                category=meta_category,
+                confidence=meta_confidence,
+                reasons=meta_reasons,
+                scan_id=scan_id,
+                metadata={"scan_type": "metadata_only"}
+            )
+            self._record_decision(asset_id, result, "automated")
+            return result
+
+        # Step 2: Scan visual content
+        visual_category, visual_confidence, visual_reasons = self.scanner.scan_visual_content(
+            file_path=file_path,
+            file_hash=file_hash
+        )
+
+        # Determine overall decision
+        reasons = meta_reasons + visual_reasons
+
+        if visual_category == ContentCategory.SAFE:
+            # High confidence safe content
+            if visual_confidence >= self.auto_approve_threshold:
+                decision = ModerationDecision.APPROVED
+                category = ContentCategory.SAFE
+                confidence = visual_confidence
+            else:
+                # Lower confidence, flag for review
+                decision = ModerationDecision.FLAGGED
+                category = ContentCategory.UNKNOWN
+                confidence = visual_confidence
+                reasons.append(f"Low confidence ({confidence:.2f}) - manual review required")
+
+        elif visual_category == ContentCategory.UNKNOWN:
+            # Uncertain content - flag for manual review
+            decision = ModerationDecision.FLAGGED
+            category = ContentCategory.UNKNOWN
+            confidence = visual_confidence
+
+        else:
+            # Inappropriate content detected
+            if visual_confidence >= self.auto_reject_threshold:
+                decision = ModerationDecision.REJECTED
+                category = visual_category
+                confidence = visual_confidence
+            else:
+                # Lower confidence rejection - flag for review
+                decision = ModerationDecision.FLAGGED
+                category = visual_category
+                confidence = visual_confidence
+                reasons.append(f"Potential violation (confidence: {confidence:.2f}) - manual review required")
+
+        result = ModerationResult(
+            decision=decision,
+            category=category,
+            confidence=confidence,
+            reasons=reasons,
+            scan_id=scan_id,
+            metadata={
+                "scan_type": "full",
+                "metadata_check": "passed",
+                "visual_check": visual_category.value
+            }
+        )
+
+        self._record_decision(asset_id, result, "automated")
+        return result
+
+    def manual_review(
+        self,
+        asset_id: str,
+        scan_id: str,
+        decision: ModerationDecision,
+        reviewer_id: str,
+        notes: str = ""
+    ) -> AuditEntry:
+        """
+        Record manual review decision
+
+        Args:
+            asset_id: Asset being reviewed
+            scan_id: Original scan ID
+            decision: Manual review decision
+            reviewer_id: ID of human reviewer
+            notes: Review notes
+
+        Returns:
+            AuditEntry for the manual review
+        """
+        audit_id = self._generate_audit_id(scan_id)
+
+        # Determine category based on decision
+        if decision == ModerationDecision.APPROVED:
+            category = ContentCategory.SAFE
+        elif decision == ModerationDecision.REJECTED:
+            category = ContentCategory.NSFW  # Default for manual rejection
+        else:
+            category = ContentCategory.UNKNOWN
+
+        entry = AuditEntry(
+            audit_id=audit_id,
+            asset_id=asset_id,
+            decision=decision,
+            category=category,
+            confidence=1.0,  # Manual review is definitive
+            moderator=reviewer_id,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            reasons=[f"Manual review: {notes}"] if notes else ["Manual review"],
+            metadata={
+                "scan_id": scan_id,
+                "review_type": "manual"
+            }
+        )
+
+        if self.enable_audit:
+            self._audit_trail.append(entry)
+
+        self._stats[decision.value] = self._stats.get(decision.value, 0) + 1
+
+        return entry
+
+    def _record_decision(
+        self,
+        asset_id: str,
+        result: ModerationResult,
+        moderator: str
+    ) -> None:
+        """Record moderation decision in audit trail"""
+        if not self.enable_audit:
+            return
+
+        audit_id = self._generate_audit_id(result.scan_id)
+
+        entry = AuditEntry(
+            audit_id=audit_id,
+            asset_id=asset_id,
+            decision=result.decision,
+            category=result.category,
+            confidence=result.confidence,
+            moderator=moderator,
+            timestamp=result.timestamp,
+            reasons=result.reasons,
+            metadata=result.metadata
+        )
+
+        self._audit_trail.append(entry)
+        self._stats[result.decision.value] += 1
+
+    def get_audit_trail(
+        self,
+        asset_id: Optional[str] = None,
+        decision: Optional[ModerationDecision] = None,
+        limit: int = 100
+    ) -> List[AuditEntry]:
+        """
+        Get audit trail entries
+
+        Args:
+            asset_id: Filter by asset ID
+            decision: Filter by decision type
+            limit: Maximum entries to return
+
+        Returns:
+            List of audit entries
+        """
+        entries = self._audit_trail
+
+        if asset_id:
+            entries = [e for e in entries if e.asset_id == asset_id]
+
+        if decision:
+            entries = [e for e in entries if e.decision == decision]
+
+        return entries[-limit:]
+
+    def get_statistics(self) -> Dict:
+        """
+        Get moderation statistics
+
+        Returns:
+            Dictionary with statistics
+        """
+        stats = self._stats.copy()
+
+        if stats["total_scans"] > 0:
+            stats["approval_rate"] = stats["approved"] / stats["total_scans"] * 100
+            stats["rejection_rate"] = stats["rejected"] / stats["total_scans"] * 100
+            stats["flag_rate"] = stats["flagged"] / stats["total_scans"] * 100
+        else:
+            stats["approval_rate"] = 0.0
+            stats["rejection_rate"] = 0.0
+            stats["flag_rate"] = 0.0
+
+        return stats
+
+    def clear_audit_trail(self, asset_id: Optional[str] = None) -> None:
+        """
+        Clear audit trail
+
+        Args:
+            asset_id: Clear entries for specific asset, or all if None
+        """
+        if asset_id:
+            self._audit_trail = [
+                e for e in self._audit_trail if e.asset_id != asset_id
+            ]
+        else:
+            self._audit_trail.clear()
+
+    def export_audit_trail(
+        self,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None
+    ) -> List[Dict]:
+        """
+        Export audit trail for compliance reporting
+
+        Args:
+            start_time: ISO format start time
+            end_time: ISO format end time
+
+        Returns:
+            List of audit entries as dictionaries
+        """
+        entries = self._audit_trail
+
+        if start_time:
+            entries = [e for e in entries if e.timestamp >= start_time]
+
+        if end_time:
+            entries = [e for e in entries if e.timestamp <= end_time]
+
+        return [
+            {
+                "audit_id": e.audit_id,
+                "asset_id": e.asset_id,
+                "decision": e.decision.value,
+                "category": e.category.value,
+                "confidence": e.confidence,
+                "moderator": e.moderator,
+                "timestamp": e.timestamp,
+                "reasons": e.reasons,
+                "metadata": e.metadata
+            }
+            for e in entries
+        ]

--- a/observability.py
+++ b/observability.py
@@ -1,0 +1,558 @@
+"""
+Observability module for logging, metrics, and tracing
+
+Provides structured logging, metrics collection, and distributed tracing
+for monitoring and debugging GIFDistributor services.
+"""
+
+import logging
+import time
+import json
+from typing import Dict, Any, Optional, List
+from datetime import datetime
+from enum import Enum
+from collections import defaultdict
+from dataclasses import dataclass, field, asdict
+import contextvars
+
+# Context variable for trace ID
+_trace_context = contextvars.ContextVar('trace_context', default=None)
+
+
+class LogLevel(Enum):
+    """Standard log levels"""
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+class MetricType(Enum):
+    """Types of metrics"""
+    COUNTER = "counter"
+    GAUGE = "gauge"
+    HISTOGRAM = "histogram"
+    TIMER = "timer"
+
+
+@dataclass
+class LogEntry:
+    """Structured log entry"""
+    timestamp: str
+    level: str
+    message: str
+    service: str
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        """Convert to JSON string"""
+        return json.dumps(asdict(self))
+
+
+@dataclass
+class Metric:
+    """Metric data point"""
+    name: str
+    value: float
+    metric_type: str
+    timestamp: str
+    tags: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary"""
+        return asdict(self)
+
+
+@dataclass
+class Span:
+    """Distributed tracing span"""
+    trace_id: str
+    span_id: str
+    parent_span_id: Optional[str]
+    operation: str
+    start_time: float
+    end_time: Optional[float] = None
+    duration_ms: Optional[float] = None
+    status: str = "in_progress"  # in_progress, success, error
+    tags: Dict[str, str] = field(default_factory=dict)
+    logs: List[Dict[str, Any]] = field(default_factory=list)
+
+    def finish(self, status: str = "success"):
+        """Complete the span"""
+        self.end_time = time.time()
+        self.duration_ms = (self.end_time - self.start_time) * 1000
+        self.status = status
+
+    def add_log(self, message: str, level: str = "INFO", **kwargs):
+        """Add a log entry to this span"""
+        self.logs.append({
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "level": level,
+            "message": message,
+            **kwargs
+        })
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary"""
+        return asdict(self)
+
+
+class StructuredLogger:
+    """
+    Structured JSON logger with trace context support
+
+    Provides consistent structured logging across services with
+    automatic trace ID injection and metadata support.
+    """
+
+    def __init__(self, service_name: str, min_level: LogLevel = LogLevel.INFO):
+        """
+        Initialize structured logger
+
+        Args:
+            service_name: Name of the service
+            min_level: Minimum log level to emit
+        """
+        self.service_name = service_name
+        self.min_level = min_level
+        self._logs: List[LogEntry] = []
+
+    def _should_log(self, level: LogLevel) -> bool:
+        """Check if message at level should be logged"""
+        levels = [LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARNING,
+                  LogLevel.ERROR, LogLevel.CRITICAL]
+        return levels.index(level) >= levels.index(self.min_level)
+
+    def _log(self, level: LogLevel, message: str, **metadata):
+        """Internal log method"""
+        if not self._should_log(level):
+            return
+
+        trace_ctx = _trace_context.get()
+        trace_id = trace_ctx.trace_id if trace_ctx else None
+        span_id = trace_ctx.span_id if trace_ctx else None
+
+        entry = LogEntry(
+            timestamp=datetime.utcnow().isoformat() + "Z",
+            level=level.value,
+            message=message,
+            service=self.service_name,
+            trace_id=trace_id,
+            span_id=span_id,
+            metadata=metadata
+        )
+        self._logs.append(entry)
+
+        # Also log to standard logging
+        log_func = getattr(logging, level.value.lower())
+        log_func(entry.to_json())
+
+    def debug(self, message: str, **metadata):
+        """Log debug message"""
+        self._log(LogLevel.DEBUG, message, **metadata)
+
+    def info(self, message: str, **metadata):
+        """Log info message"""
+        self._log(LogLevel.INFO, message, **metadata)
+
+    def warning(self, message: str, **metadata):
+        """Log warning message"""
+        self._log(LogLevel.WARNING, message, **metadata)
+
+    def error(self, message: str, **metadata):
+        """Log error message"""
+        self._log(LogLevel.ERROR, message, **metadata)
+
+    def critical(self, message: str, **metadata):
+        """Log critical message"""
+        self._log(LogLevel.CRITICAL, message, **metadata)
+
+    def get_logs(self, trace_id: Optional[str] = None) -> List[LogEntry]:
+        """
+        Get log entries, optionally filtered by trace ID
+
+        Args:
+            trace_id: Optional trace ID to filter by
+
+        Returns:
+            List of log entries
+        """
+        if trace_id is None:
+            return self._logs.copy()
+        return [log for log in self._logs if log.trace_id == trace_id]
+
+    def clear_logs(self):
+        """Clear all stored logs"""
+        self._logs.clear()
+
+
+class MetricsCollector:
+    """
+    Metrics collector for counters, gauges, histograms, and timers
+
+    Collects and aggregates metrics for monitoring service health
+    and performance.
+    """
+
+    def __init__(self):
+        """Initialize metrics collector"""
+        self._counters: Dict[str, float] = defaultdict(float)
+        self._gauges: Dict[str, float] = {}
+        self._histograms: Dict[str, List[float]] = defaultdict(list)
+        self._metrics: List[Metric] = []
+
+    def increment_counter(self, name: str, value: float = 1.0, tags: Optional[Dict[str, str]] = None):
+        """
+        Increment a counter metric
+
+        Args:
+            name: Counter name
+            value: Amount to increment (default 1.0)
+            tags: Optional tags for the metric
+        """
+        key = self._make_key(name, tags or {})
+        self._counters[key] += value
+
+        metric = Metric(
+            name=name,
+            value=value,
+            metric_type=MetricType.COUNTER.value,
+            timestamp=datetime.utcnow().isoformat() + "Z",
+            tags=tags or {}
+        )
+        self._metrics.append(metric)
+
+    def set_gauge(self, name: str, value: float, tags: Optional[Dict[str, str]] = None):
+        """
+        Set a gauge metric to a specific value
+
+        Args:
+            name: Gauge name
+            value: Current value
+            tags: Optional tags for the metric
+        """
+        key = self._make_key(name, tags or {})
+        self._gauges[key] = value
+
+        metric = Metric(
+            name=name,
+            value=value,
+            metric_type=MetricType.GAUGE.value,
+            timestamp=datetime.utcnow().isoformat() + "Z",
+            tags=tags or {}
+        )
+        self._metrics.append(metric)
+
+    def record_histogram(self, name: str, value: float, tags: Optional[Dict[str, str]] = None):
+        """
+        Record a value in a histogram
+
+        Args:
+            name: Histogram name
+            value: Value to record
+            tags: Optional tags for the metric
+        """
+        key = self._make_key(name, tags or {})
+        self._histograms[key].append(value)
+
+        metric = Metric(
+            name=name,
+            value=value,
+            metric_type=MetricType.HISTOGRAM.value,
+            timestamp=datetime.utcnow().isoformat() + "Z",
+            tags=tags or {}
+        )
+        self._metrics.append(metric)
+
+    def time_operation(self, name: str, tags: Optional[Dict[str, str]] = None):
+        """
+        Context manager for timing operations
+
+        Args:
+            name: Timer name
+            tags: Optional tags for the metric
+
+        Usage:
+            with collector.time_operation("db_query"):
+                # code to time
+                pass
+        """
+        return Timer(self, name, tags or {})
+
+    def get_counter(self, name: str, tags: Optional[Dict[str, str]] = None) -> float:
+        """Get current counter value"""
+        key = self._make_key(name, tags or {})
+        return self._counters.get(key, 0.0)
+
+    def get_gauge(self, name: str, tags: Optional[Dict[str, str]] = None) -> Optional[float]:
+        """Get current gauge value"""
+        key = self._make_key(name, tags or {})
+        return self._gauges.get(key)
+
+    def get_histogram_stats(self, name: str, tags: Optional[Dict[str, str]] = None) -> Dict[str, float]:
+        """
+        Get statistics for a histogram
+
+        Returns:
+            Dictionary with min, max, mean, median, p95, p99
+        """
+        key = self._make_key(name, tags or {})
+        values = self._histograms.get(key, [])
+
+        if not values:
+            return {}
+
+        sorted_values = sorted(values)
+        n = len(sorted_values)
+
+        p95_idx = max(0, int(n * 0.95) - 1)
+        p99_idx = max(0, int(n * 0.99) - 1)
+
+        return {
+            "min": sorted_values[0],
+            "max": sorted_values[-1],
+            "mean": sum(sorted_values) / n,
+            "median": sorted_values[n // 2],
+            "p95": sorted_values[p95_idx],
+            "p99": sorted_values[p99_idx],
+            "count": n
+        }
+
+    def get_all_metrics(self) -> List[Metric]:
+        """Get all recorded metrics"""
+        return self._metrics.copy()
+
+    def clear_metrics(self):
+        """Clear all metrics"""
+        self._counters.clear()
+        self._gauges.clear()
+        self._histograms.clear()
+        self._metrics.clear()
+
+    def _make_key(self, name: str, tags: Dict[str, str]) -> str:
+        """Create a unique key from metric name and tags"""
+        if not tags:
+            return name
+        tag_str = ",".join(f"{k}={v}" for k, v in sorted(tags.items()))
+        return f"{name}{{{tag_str}}}"
+
+
+class Timer:
+    """Context manager for timing operations"""
+
+    def __init__(self, collector: MetricsCollector, name: str, tags: Dict[str, str]):
+        self.collector = collector
+        self.name = name
+        self.tags = tags
+        self.start_time = None
+
+    def __enter__(self):
+        self.start_time = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        duration_ms = (time.time() - self.start_time) * 1000
+        self.collector.record_histogram(self.name, duration_ms, self.tags)
+
+
+class Tracer:
+    """
+    Distributed tracing implementation
+
+    Creates and manages spans for distributed tracing across services.
+    """
+
+    def __init__(self):
+        """Initialize tracer"""
+        self._spans: Dict[str, List[Span]] = defaultdict(list)
+        self._active_spans: Dict[str, Span] = {}
+        self._span_counter = 0
+
+    def start_trace(self, operation: str, tags: Optional[Dict[str, str]] = None) -> Span:
+        """
+        Start a new trace (root span)
+
+        Args:
+            operation: Name of the operation
+            tags: Optional tags for the span
+
+        Returns:
+            New root span
+        """
+        trace_id = self._generate_trace_id()
+        span_id = self._generate_span_id()
+
+        span = Span(
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_span_id=None,
+            operation=operation,
+            start_time=time.time(),
+            tags=tags or {}
+        )
+
+        self._spans[trace_id].append(span)
+        self._active_spans[span_id] = span
+
+        # Set trace context
+        _trace_context.set(span)
+
+        return span
+
+    def start_span(self, operation: str, parent_span: Span,
+                   tags: Optional[Dict[str, str]] = None) -> Span:
+        """
+        Start a child span
+
+        Args:
+            operation: Name of the operation
+            parent_span: Parent span
+            tags: Optional tags for the span
+
+        Returns:
+            New child span
+        """
+        span_id = self._generate_span_id()
+
+        span = Span(
+            trace_id=parent_span.trace_id,
+            span_id=span_id,
+            parent_span_id=parent_span.span_id,
+            operation=operation,
+            start_time=time.time(),
+            tags=tags or {}
+        )
+
+        self._spans[parent_span.trace_id].append(span)
+        self._active_spans[span_id] = span
+
+        # Update trace context
+        _trace_context.set(span)
+
+        return span
+
+    def finish_span(self, span: Span, status: str = "success"):
+        """
+        Finish a span
+
+        Args:
+            span: Span to finish
+            status: Status (success, error)
+        """
+        span.finish(status)
+        if span.span_id in self._active_spans:
+            del self._active_spans[span.span_id]
+
+    def get_trace(self, trace_id: str) -> List[Span]:
+        """
+        Get all spans for a trace
+
+        Args:
+            trace_id: Trace ID
+
+        Returns:
+            List of spans in the trace
+        """
+        return self._spans.get(trace_id, []).copy()
+
+    def get_all_traces(self) -> Dict[str, List[Span]]:
+        """Get all traces"""
+        return {k: v.copy() for k, v in self._spans.items()}
+
+    def clear_traces(self):
+        """Clear all traces"""
+        self._spans.clear()
+        self._active_spans.clear()
+
+    def _generate_trace_id(self) -> str:
+        """Generate a unique trace ID"""
+        import uuid
+        return uuid.uuid4().hex
+
+    def _generate_span_id(self) -> str:
+        """Generate a unique span ID"""
+        self._span_counter += 1
+        return f"span_{self._span_counter:08x}"
+
+
+class ObservabilityStack:
+    """
+    Unified observability stack combining logs, metrics, and traces
+
+    Provides a single interface for all observability needs.
+    """
+
+    def __init__(self, service_name: str, min_log_level: LogLevel = LogLevel.INFO):
+        """
+        Initialize observability stack
+
+        Args:
+            service_name: Name of the service
+            min_log_level: Minimum log level
+        """
+        self.service_name = service_name
+        self.logger = StructuredLogger(service_name, min_log_level)
+        self.metrics = MetricsCollector()
+        self.tracer = Tracer()
+
+    def start_trace(self, operation: str, **tags) -> Span:
+        """Start a new trace"""
+        span = self.tracer.start_trace(operation, tags)
+        self.logger.info(f"Starting trace: {operation}", trace_id=span.trace_id)
+        self.metrics.increment_counter("traces.started")
+        return span
+
+    def finish_span(self, span: Span, status: str = "success"):
+        """Finish a span"""
+        self.tracer.finish_span(span, status)
+        self.logger.info(f"Finished span: {span.operation}",
+                        trace_id=span.trace_id,
+                        duration_ms=span.duration_ms,
+                        status=status)
+        self.metrics.record_histogram("span.duration", span.duration_ms)
+
+    def get_dashboard_data(self) -> Dict[str, Any]:
+        """
+        Get aggregated data for dashboard
+
+        Returns:
+            Dictionary with logs, metrics, and trace summaries
+        """
+        return {
+            "service": self.service_name,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "logs": {
+                "total": len(self.logger.get_logs()),
+                "by_level": self._count_logs_by_level()
+            },
+            "metrics": {
+                "counters": dict(self.metrics._counters),
+                "gauges": dict(self.metrics._gauges),
+                "histograms": {
+                    name: self.metrics.get_histogram_stats(name.split("{")[0],
+                                                           self._parse_tags(name))
+                    for name in self.metrics._histograms.keys()
+                }
+            },
+            "traces": {
+                "total": len(self.tracer._spans),
+                "active": len(self.tracer._active_spans)
+            }
+        }
+
+    def _count_logs_by_level(self) -> Dict[str, int]:
+        """Count logs by level"""
+        counts = defaultdict(int)
+        for log in self.logger.get_logs():
+            counts[log.level] += 1
+        return dict(counts)
+
+    def _parse_tags(self, key: str) -> Dict[str, str]:
+        """Parse tags from metric key"""
+        if "{" not in key:
+            return {}
+        tag_str = key.split("{")[1].rstrip("}")
+        return dict(pair.split("=") for pair in tag_str.split(",") if pair)

--- a/ratelimit.py
+++ b/ratelimit.py
@@ -1,0 +1,381 @@
+"""
+Rate Limiting Module for GIF Distributor
+Provides rate limiting and abuse protection
+Issue: #22
+"""
+import time
+from typing import Dict, Optional, Tuple
+from enum import Enum
+from collections import deque
+from dataclasses import dataclass, field
+
+
+class RateLimitStrategy(Enum):
+    """Rate limiting strategies"""
+    TOKEN_BUCKET = "token_bucket"
+    FIXED_WINDOW = "fixed_window"
+    SLIDING_WINDOW = "sliding_window"
+
+
+class RateLimitError(Exception):
+    """Exception raised when rate limit is exceeded"""
+    pass
+
+
+@dataclass
+class RateLimitConfig:
+    """Configuration for rate limiting"""
+    requests_per_window: int
+    window_seconds: int
+    strategy: RateLimitStrategy = RateLimitStrategy.TOKEN_BUCKET
+
+
+@dataclass
+class TokenBucket:
+    """Token bucket for rate limiting"""
+    capacity: int
+    refill_rate: float  # tokens per second
+    tokens: float = field(init=False)
+    last_refill: float = field(init=False)
+
+    def __post_init__(self):
+        self.tokens = float(self.capacity)
+        self.last_refill = time.time()
+
+    def consume(self, tokens: int = 1) -> bool:
+        """
+        Try to consume tokens from the bucket
+
+        Args:
+            tokens: Number of tokens to consume
+
+        Returns:
+            True if tokens were consumed, False if not enough tokens
+        """
+        self._refill()
+
+        if self.tokens >= tokens:
+            self.tokens -= tokens
+            return True
+        return False
+
+    def _refill(self) -> None:
+        """Refill tokens based on elapsed time"""
+        now = time.time()
+        elapsed = now - self.last_refill
+
+        # Add tokens based on elapsed time
+        new_tokens = elapsed * self.refill_rate
+        self.tokens = min(self.capacity, self.tokens + new_tokens)
+        self.last_refill = now
+
+    def get_wait_time(self, tokens: int = 1) -> float:
+        """
+        Get time to wait until tokens are available
+
+        Args:
+            tokens: Number of tokens needed
+
+        Returns:
+            Seconds to wait (0 if tokens available now)
+        """
+        self._refill()
+
+        if self.tokens >= tokens:
+            return 0.0
+
+        tokens_needed = tokens - self.tokens
+        return tokens_needed / self.refill_rate
+
+
+@dataclass
+class FixedWindow:
+    """Fixed window rate limiter"""
+    limit: int
+    window_seconds: int
+    count: int = 0
+    window_start: float = field(default_factory=time.time)
+
+    def consume(self, count: int = 1) -> bool:
+        """
+        Try to consume from the window
+
+        Args:
+            count: Number of requests to consume
+
+        Returns:
+            True if request allowed, False if limit exceeded
+        """
+        now = time.time()
+
+        # Reset window if expired
+        if now - self.window_start >= self.window_seconds:
+            self.count = 0
+            self.window_start = now
+
+        if self.count + count <= self.limit:
+            self.count += count
+            return True
+        return False
+
+    def get_wait_time(self, count: int = 1) -> float:
+        """
+        Get time to wait until next window
+
+        Returns:
+            Seconds to wait (0 if requests available now)
+        """
+        now = time.time()
+
+        # Check if window expired
+        if now - self.window_start >= self.window_seconds:
+            return 0.0
+
+        if self.count + count <= self.limit:
+            return 0.0
+
+        # Wait until window resets
+        return self.window_seconds - (now - self.window_start)
+
+
+@dataclass
+class SlidingWindow:
+    """Sliding window rate limiter"""
+    limit: int
+    window_seconds: int
+    timestamps: deque = field(default_factory=deque)
+
+    def consume(self, count: int = 1) -> bool:
+        """
+        Try to consume from the sliding window
+
+        Args:
+            count: Number of requests to consume
+
+        Returns:
+            True if request allowed, False if limit exceeded
+        """
+        now = time.time()
+
+        # Remove expired timestamps
+        cutoff = now - self.window_seconds
+        while self.timestamps and self.timestamps[0] < cutoff:
+            self.timestamps.popleft()
+
+        if len(self.timestamps) + count <= self.limit:
+            for _ in range(count):
+                self.timestamps.append(now)
+            return True
+        return False
+
+    def get_wait_time(self, count: int = 1) -> float:
+        """
+        Get time to wait until request can be made
+
+        Returns:
+            Seconds to wait (0 if requests available now)
+        """
+        now = time.time()
+
+        # Remove expired timestamps
+        cutoff = now - self.window_seconds
+        while self.timestamps and self.timestamps[0] < cutoff:
+            self.timestamps.popleft()
+
+        if len(self.timestamps) + count <= self.limit:
+            return 0.0
+
+        # Calculate when oldest request will expire
+        if self.timestamps:
+            return (self.timestamps[0] + self.window_seconds) - now
+        return 0.0
+
+
+class RateLimiter:
+    """Main rate limiter with support for multiple strategies"""
+
+    def __init__(
+        self,
+        config: RateLimitConfig,
+        enable_per_ip: bool = True,
+        enable_per_user: bool = True
+    ):
+        """
+        Initialize the rate limiter
+
+        Args:
+            config: Rate limit configuration
+            enable_per_ip: Enable IP-based rate limiting
+            enable_per_user: Enable user-based rate limiting
+        """
+        self.config = config
+        self.enable_per_ip = enable_per_ip
+        self.enable_per_user = enable_per_user
+
+        # Storage for rate limiters per identifier
+        self._ip_limiters: Dict[str, any] = {}
+        self._user_limiters: Dict[str, any] = {}
+
+    def _create_limiter(self):
+        """Create a new limiter instance based on strategy"""
+        if self.config.strategy == RateLimitStrategy.TOKEN_BUCKET:
+            refill_rate = self.config.requests_per_window / self.config.window_seconds
+            return TokenBucket(
+                capacity=self.config.requests_per_window,
+                refill_rate=refill_rate
+            )
+        elif self.config.strategy == RateLimitStrategy.FIXED_WINDOW:
+            return FixedWindow(
+                limit=self.config.requests_per_window,
+                window_seconds=self.config.window_seconds
+            )
+        elif self.config.strategy == RateLimitStrategy.SLIDING_WINDOW:
+            return SlidingWindow(
+                limit=self.config.requests_per_window,
+                window_seconds=self.config.window_seconds
+            )
+        else:
+            raise ValueError(f"Unknown strategy: {self.config.strategy}")
+
+    def check_rate_limit(
+        self,
+        ip_address: Optional[str] = None,
+        user_id: Optional[str] = None,
+        count: int = 1
+    ) -> Tuple[bool, Optional[float]]:
+        """
+        Check if request is allowed under rate limits
+
+        Args:
+            ip_address: IP address of the requester
+            user_id: User ID of the requester
+            count: Number of requests to consume (default: 1)
+
+        Returns:
+            Tuple of (allowed, retry_after_seconds)
+            allowed: True if request is allowed
+            retry_after_seconds: Seconds to wait if blocked, None if allowed
+        """
+        max_wait = 0.0
+
+        # Check IP-based rate limit
+        if self.enable_per_ip and ip_address:
+            if ip_address not in self._ip_limiters:
+                self._ip_limiters[ip_address] = self._create_limiter()
+
+            limiter = self._ip_limiters[ip_address]
+            if not limiter.consume(count):
+                wait_time = limiter.get_wait_time(count)
+                return False, wait_time
+            max_wait = max(max_wait, limiter.get_wait_time(count))
+
+        # Check user-based rate limit
+        if self.enable_per_user and user_id:
+            if user_id not in self._user_limiters:
+                self._user_limiters[user_id] = self._create_limiter()
+
+            limiter = self._user_limiters[user_id]
+            if not limiter.consume(count):
+                wait_time = limiter.get_wait_time(count)
+                return False, wait_time
+            max_wait = max(max_wait, limiter.get_wait_time(count))
+
+        return True, None
+
+    def enforce_rate_limit(
+        self,
+        ip_address: Optional[str] = None,
+        user_id: Optional[str] = None,
+        count: int = 1
+    ) -> None:
+        """
+        Enforce rate limit, raising exception if exceeded
+
+        Args:
+            ip_address: IP address of the requester
+            user_id: User ID of the requester
+            count: Number of requests to consume (default: 1)
+
+        Raises:
+            RateLimitError: If rate limit is exceeded
+        """
+        allowed, retry_after = self.check_rate_limit(ip_address, user_id, count)
+
+        if not allowed:
+            raise RateLimitError(
+                f"Rate limit exceeded. Retry after {retry_after:.1f} seconds."
+            )
+
+    def get_remaining_quota(
+        self,
+        ip_address: Optional[str] = None,
+        user_id: Optional[str] = None
+    ) -> Dict[str, int]:
+        """
+        Get remaining quota for IP and user
+
+        Args:
+            ip_address: IP address to check
+            user_id: User ID to check
+
+        Returns:
+            Dictionary with 'ip' and 'user' remaining quotas
+        """
+        result = {}
+
+        if self.enable_per_ip and ip_address:
+            if ip_address in self._ip_limiters:
+                limiter = self._ip_limiters[ip_address]
+                if hasattr(limiter, 'tokens'):
+                    limiter._refill()
+                    result['ip'] = int(limiter.tokens)
+                elif hasattr(limiter, 'count'):
+                    result['ip'] = max(0, limiter.limit - limiter.count)
+                elif hasattr(limiter, 'timestamps'):
+                    now = time.time()
+                    cutoff = now - limiter.window_seconds
+                    valid_count = sum(1 for ts in limiter.timestamps if ts >= cutoff)
+                    result['ip'] = max(0, limiter.limit - valid_count)
+            else:
+                result['ip'] = self.config.requests_per_window
+
+        if self.enable_per_user and user_id:
+            if user_id in self._user_limiters:
+                limiter = self._user_limiters[user_id]
+                if hasattr(limiter, 'tokens'):
+                    limiter._refill()
+                    result['user'] = int(limiter.tokens)
+                elif hasattr(limiter, 'count'):
+                    result['user'] = max(0, limiter.limit - limiter.count)
+                elif hasattr(limiter, 'timestamps'):
+                    now = time.time()
+                    cutoff = now - limiter.window_seconds
+                    valid_count = sum(1 for ts in limiter.timestamps if ts >= cutoff)
+                    result['user'] = max(0, limiter.limit - valid_count)
+            else:
+                result['user'] = self.config.requests_per_window
+
+        return result
+
+    def reset_limits(
+        self,
+        ip_address: Optional[str] = None,
+        user_id: Optional[str] = None
+    ) -> None:
+        """
+        Reset rate limits for IP and/or user
+
+        Args:
+            ip_address: IP address to reset (None to keep)
+            user_id: User ID to reset (None to keep)
+        """
+        if ip_address and ip_address in self._ip_limiters:
+            del self._ip_limiters[ip_address]
+
+        if user_id and user_id in self._user_limiters:
+            del self._user_limiters[user_id]
+
+    def clear_all(self) -> None:
+        """Clear all rate limit data"""
+        self._ip_limiters.clear()
+        self._user_limiters.clear()

--- a/sharelinks.py
+++ b/sharelinks.py
@@ -52,7 +52,7 @@ class ShareLinkGenerator:
             "asset_id": asset_id,
             "canonical_url": canonical_url,
             "title": title,
-            "tags": tags or [],
+            "tags": list(tags) if tags else [],
             "created_at": datetime.utcnow().isoformat(),
             "clicks": 0
         }

--- a/storage_cdn.py
+++ b/storage_cdn.py
@@ -1,0 +1,696 @@
+"""
+Object Storage + CDN Module - Issue #27
+Provides object storage with CDN integration and signed URLs
+
+Features:
+- Abstract storage interface supporting multiple backends (S3, R2, local)
+- CDN integration with cache headers and invalidation
+- Signed URLs for secure, time-limited access
+- Metadata management and storage optimization
+- Multi-region support and replication
+"""
+
+import os
+import time
+import hmac
+import hashlib
+import base64
+import json
+from typing import Dict, List, Optional, Tuple, Any, BinaryIO
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from datetime import datetime, timezone, timedelta
+from enum import Enum
+from urllib.parse import urlencode, quote
+import mimetypes
+
+
+class StorageBackend(str, Enum):
+    """Supported storage backends"""
+    LOCAL = "local"
+    S3 = "s3"
+    R2 = "r2"  # Cloudflare R2
+    GCS = "gcs"  # Google Cloud Storage
+    AZURE = "azure"
+
+
+class CachePolicy(str, Enum):
+    """CDN cache policies"""
+    NO_CACHE = "no-cache"
+    PUBLIC = "public"
+    PRIVATE = "private"
+    IMMUTABLE = "immutable"
+
+
+@dataclass
+class StorageConfig:
+    """Storage configuration"""
+    backend: StorageBackend
+    bucket_name: str
+    region: Optional[str] = None
+    access_key: Optional[str] = None
+    secret_key: Optional[str] = None
+    endpoint_url: Optional[str] = None
+    cdn_domain: Optional[str] = None
+    base_path: Optional[str] = None  # For local storage
+
+
+@dataclass
+class ObjectMetadata:
+    """Metadata for stored objects"""
+    key: str
+    size_bytes: int
+    content_type: str
+    etag: str
+    last_modified: str
+    cache_control: Optional[str] = None
+    expires: Optional[str] = None
+    custom_metadata: Dict[str, str] = field(default_factory=dict)
+    cdn_url: Optional[str] = None
+    storage_class: str = "STANDARD"
+
+
+@dataclass
+class SignedUrlConfig:
+    """Configuration for signed URLs"""
+    expires_in_seconds: int = 3600
+    allow_methods: List[str] = field(default_factory=lambda: ["GET"])
+    max_size_bytes: Optional[int] = None
+    content_type: Optional[str] = None
+    custom_params: Dict[str, str] = field(default_factory=dict)
+
+
+class LocalStorageBackend:
+    """
+    Local filesystem storage backend
+    Useful for development and testing
+    """
+
+    def __init__(self, config: StorageConfig):
+        """Initialize local storage"""
+        self.config = config
+        self.base_path = config.base_path or "./storage"
+        os.makedirs(self.base_path, exist_ok=True)
+
+    def _get_full_path(self, key: str) -> str:
+        """Get full filesystem path for key"""
+        # Normalize key to prevent directory traversal
+        safe_key = key.replace('..', '').lstrip('/')
+        return os.path.join(self.base_path, safe_key)
+
+    def put_object(
+        self,
+        key: str,
+        data: bytes,
+        content_type: str = "application/octet-stream",
+        metadata: Optional[Dict[str, str]] = None,
+        cache_control: Optional[str] = None
+    ) -> ObjectMetadata:
+        """
+        Store object in local filesystem
+
+        Args:
+            key: Object key/path
+            data: Object data
+            content_type: Content type
+            metadata: Custom metadata
+            cache_control: Cache control header
+
+        Returns:
+            ObjectMetadata
+        """
+        full_path = self._get_full_path(key)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+
+        # Write data
+        with open(full_path, 'wb') as f:
+            f.write(data)
+
+        # Calculate ETag (MD5 hash)
+        etag = hashlib.md5(data).hexdigest()
+
+        # Store metadata separately
+        metadata_path = full_path + '.meta'
+        meta = {
+            'content_type': content_type,
+            'custom_metadata': metadata or {},
+            'cache_control': cache_control,
+            'etag': etag
+        }
+        with open(metadata_path, 'w') as f:
+            json.dump(meta, f)
+
+        return ObjectMetadata(
+            key=key,
+            size_bytes=len(data),
+            content_type=content_type,
+            etag=etag,
+            last_modified=datetime.now(timezone.utc).isoformat(),
+            cache_control=cache_control,
+            custom_metadata=metadata or {}
+        )
+
+    def get_object(self, key: str) -> Tuple[bytes, ObjectMetadata]:
+        """
+        Retrieve object from local filesystem
+
+        Args:
+            key: Object key
+
+        Returns:
+            Tuple of (data, metadata)
+        """
+        full_path = self._get_full_path(key)
+
+        if not os.path.exists(full_path):
+            raise FileNotFoundError(f"Object not found: {key}")
+
+        # Read data
+        with open(full_path, 'rb') as f:
+            data = f.read()
+
+        # Read metadata
+        metadata_path = full_path + '.meta'
+        if os.path.exists(metadata_path):
+            with open(metadata_path, 'r') as f:
+                meta = json.load(f)
+        else:
+            meta = {'content_type': 'application/octet-stream'}
+
+        stat = os.stat(full_path)
+        metadata = ObjectMetadata(
+            key=key,
+            size_bytes=stat.st_size,
+            content_type=meta.get('content_type', 'application/octet-stream'),
+            etag=meta.get('etag', hashlib.md5(data).hexdigest()),
+            last_modified=datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+            cache_control=meta.get('cache_control'),
+            custom_metadata=meta.get('custom_metadata', {})
+        )
+
+        return (data, metadata)
+
+    def delete_object(self, key: str) -> bool:
+        """
+        Delete object from local filesystem
+
+        Args:
+            key: Object key
+
+        Returns:
+            True if deleted, False if not found
+        """
+        full_path = self._get_full_path(key)
+
+        if not os.path.exists(full_path):
+            return False
+
+        os.remove(full_path)
+
+        # Remove metadata if exists
+        metadata_path = full_path + '.meta'
+        if os.path.exists(metadata_path):
+            os.remove(metadata_path)
+
+        return True
+
+    def list_objects(self, prefix: str = "", max_keys: int = 1000) -> List[ObjectMetadata]:
+        """
+        List objects with given prefix
+
+        Args:
+            prefix: Key prefix filter
+            max_keys: Maximum number of results
+
+        Returns:
+            List of ObjectMetadata
+        """
+        results = []
+
+        for root, dirs, files in os.walk(self.base_path):
+            if len(results) >= max_keys:
+                break
+
+            for filename in files:
+                if filename.endswith('.meta'):
+                    continue
+
+                full_path = os.path.join(root, filename)
+
+                # Get relative key
+                rel_path = os.path.relpath(full_path, self.base_path)
+                key = rel_path.replace(os.sep, '/')
+
+                # Filter by prefix using the key (not full path)
+                if prefix and not key.startswith(prefix):
+                    continue
+
+                # Get metadata
+                stat = os.stat(full_path)
+                metadata_path = full_path + '.meta'
+                if os.path.exists(metadata_path):
+                    with open(metadata_path, 'r') as f:
+                        meta = json.load(f)
+                else:
+                    meta = {}
+
+                results.append(ObjectMetadata(
+                    key=key,
+                    size_bytes=stat.st_size,
+                    content_type=meta.get('content_type', 'application/octet-stream'),
+                    etag=meta.get('etag', ''),
+                    last_modified=datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+                    custom_metadata=meta.get('custom_metadata', {})
+                ))
+
+                if len(results) >= max_keys:
+                    break
+
+        return results
+
+    def object_exists(self, key: str) -> bool:
+        """Check if object exists"""
+        return os.path.exists(self._get_full_path(key))
+
+
+class SignedUrlGenerator:
+    """
+    Generate signed URLs for secure, time-limited access
+    Supports HMAC-SHA256 based signing
+    """
+
+    def __init__(self, secret_key: str):
+        """
+        Initialize signed URL generator
+
+        Args:
+            secret_key: Secret key for signing
+        """
+        self.secret_key = secret_key.encode() if isinstance(secret_key, str) else secret_key
+
+    def generate_signed_url(
+        self,
+        base_url: str,
+        key: str,
+        config: Optional[SignedUrlConfig] = None
+    ) -> str:
+        """
+        Generate signed URL
+
+        Args:
+            base_url: Base URL (domain)
+            key: Object key
+            config: Signed URL configuration
+
+        Returns:
+            Signed URL string
+        """
+        config = config or SignedUrlConfig()
+
+        # Calculate expiration timestamp
+        expires_at = int(time.time()) + config.expires_in_seconds
+
+        # Build parameters
+        params = {
+            'expires': expires_at,
+            'key': key,
+        }
+
+        # Add optional parameters
+        if config.content_type:
+            params['content_type'] = config.content_type
+
+        if config.max_size_bytes:
+            params['max_size'] = config.max_size_bytes
+
+        # Add custom parameters
+        params.update(config.custom_params)
+
+        # Create signature payload
+        payload = f"{key}:{expires_at}"
+        if config.content_type:
+            payload += f":{config.content_type}"
+
+        # Generate signature
+        signature = hmac.new(
+            self.secret_key,
+            payload.encode(),
+            hashlib.sha256
+        ).digest()
+
+        # Encode signature
+        sig_b64 = base64.urlsafe_b64encode(signature).decode().rstrip('=')
+        params['signature'] = sig_b64
+
+        # Build URL
+        query_string = urlencode(params)
+        return f"{base_url}/{quote(key, safe='')}?{query_string}"
+
+    def verify_signed_url(
+        self,
+        key: str,
+        signature: str,
+        expires: int,
+        content_type: Optional[str] = None
+    ) -> bool:
+        """
+        Verify signed URL
+
+        Args:
+            key: Object key
+            signature: URL signature
+            expires: Expiration timestamp
+            content_type: Expected content type
+
+        Returns:
+            True if valid, False otherwise
+        """
+        # Check expiration
+        if time.time() > expires:
+            return False
+
+        # Recreate payload
+        payload = f"{key}:{expires}"
+        if content_type:
+            payload += f":{content_type}"
+
+        # Generate expected signature
+        expected_sig = hmac.new(
+            self.secret_key,
+            payload.encode(),
+            hashlib.sha256
+        ).digest()
+
+        expected_sig_b64 = base64.urlsafe_b64encode(expected_sig).decode().rstrip('=')
+
+        # Compare signatures (constant time)
+        return hmac.compare_digest(signature, expected_sig_b64)
+
+
+class CDNManager:
+    """
+    Manage CDN integration and cache control
+    """
+
+    def __init__(self, cdn_domain: Optional[str] = None):
+        """
+        Initialize CDN manager
+
+        Args:
+            cdn_domain: CDN domain (e.g., cdn.example.com)
+        """
+        self.cdn_domain = cdn_domain
+
+    def get_cdn_url(self, key: str, use_https: bool = True) -> str:
+        """
+        Get CDN URL for object
+
+        Args:
+            key: Object key
+            use_https: Use HTTPS protocol
+
+        Returns:
+            CDN URL
+        """
+        if not self.cdn_domain:
+            raise ValueError("CDN domain not configured")
+
+        protocol = "https" if use_https else "http"
+        safe_key = quote(key, safe='')
+        return f"{protocol}://{self.cdn_domain}/{safe_key}"
+
+    def get_cache_headers(
+        self,
+        policy: CachePolicy = CachePolicy.PUBLIC,
+        max_age: int = 86400,
+        stale_while_revalidate: Optional[int] = None,
+        immutable: bool = False
+    ) -> Dict[str, str]:
+        """
+        Generate cache control headers
+
+        Args:
+            policy: Cache policy
+            max_age: Max age in seconds
+            stale_while_revalidate: Stale-while-revalidate in seconds
+            immutable: Mark as immutable
+
+        Returns:
+            Dictionary of cache headers
+        """
+        headers = {}
+
+        # Build Cache-Control header
+        cache_parts = [policy.value]
+
+        if policy != CachePolicy.NO_CACHE:
+            cache_parts.append(f"max-age={max_age}")
+
+        if stale_while_revalidate:
+            cache_parts.append(f"stale-while-revalidate={stale_while_revalidate}")
+
+        if immutable:
+            cache_parts.append("immutable")
+
+        headers['Cache-Control'] = ', '.join(cache_parts)
+
+        # Add Expires header for older clients
+        if policy != CachePolicy.NO_CACHE:
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=max_age)
+            headers['Expires'] = expires_at.strftime('%a, %d %b %Y %H:%M:%S GMT')
+
+        return headers
+
+    def invalidate_cache(self, keys: List[str]) -> Dict[str, Any]:
+        """
+        Invalidate CDN cache for given keys
+        Note: This is a placeholder - actual implementation depends on CDN provider
+
+        Args:
+            keys: List of object keys to invalidate
+
+        Returns:
+            Invalidation result
+        """
+        # In production, this would call the CDN provider's API
+        # For now, just return a mock result
+        return {
+            'invalidation_id': hashlib.sha256(
+                f"{','.join(keys)}:{time.time()}".encode()
+            ).hexdigest()[:16],
+            'keys': keys,
+            'status': 'pending',
+            'created_at': datetime.now(timezone.utc).isoformat()
+        }
+
+
+class StorageManager:
+    """
+    High-level storage manager with CDN and signed URL support
+    """
+
+    def __init__(
+        self,
+        config: StorageConfig,
+        signing_secret: Optional[str] = None
+    ):
+        """
+        Initialize storage manager
+
+        Args:
+            config: Storage configuration
+            signing_secret: Secret for signed URLs
+        """
+        self.config = config
+
+        # Initialize backend
+        if config.backend == StorageBackend.LOCAL:
+            self.backend = LocalStorageBackend(config)
+        else:
+            raise NotImplementedError(f"Backend {config.backend} not yet implemented")
+
+        # Initialize CDN manager
+        self.cdn = CDNManager(config.cdn_domain)
+
+        # Initialize signed URL generator
+        self.signing_secret = signing_secret or os.environ.get('STORAGE_SIGNING_SECRET', 'default-secret-key')
+        self.url_signer = SignedUrlGenerator(self.signing_secret)
+
+    def upload(
+        self,
+        key: str,
+        data: bytes,
+        content_type: Optional[str] = None,
+        cache_policy: CachePolicy = CachePolicy.PUBLIC,
+        max_age: int = 86400,
+        metadata: Optional[Dict[str, str]] = None
+    ) -> ObjectMetadata:
+        """
+        Upload object to storage
+
+        Args:
+            key: Object key
+            data: Object data
+            content_type: Content type (auto-detected if not provided)
+            cache_policy: CDN cache policy
+            max_age: Cache max age in seconds
+            metadata: Custom metadata
+
+        Returns:
+            ObjectMetadata
+        """
+        # Auto-detect content type
+        if not content_type:
+            content_type = mimetypes.guess_type(key)[0] or 'application/octet-stream'
+
+        # Get cache headers
+        cache_headers = self.cdn.get_cache_headers(cache_policy, max_age)
+        cache_control = cache_headers.get('Cache-Control')
+
+        # Upload to backend
+        obj_metadata = self.backend.put_object(
+            key,
+            data,
+            content_type=content_type,
+            metadata=metadata,
+            cache_control=cache_control
+        )
+
+        # Add CDN URL if configured
+        if self.config.cdn_domain:
+            obj_metadata.cdn_url = self.cdn.get_cdn_url(key)
+
+        return obj_metadata
+
+    def download(self, key: str) -> Tuple[bytes, ObjectMetadata]:
+        """
+        Download object from storage
+
+        Args:
+            key: Object key
+
+        Returns:
+            Tuple of (data, metadata)
+        """
+        return self.backend.get_object(key)
+
+    def delete(self, key: str) -> bool:
+        """
+        Delete object from storage
+
+        Args:
+            key: Object key
+
+        Returns:
+            True if deleted
+        """
+        success = self.backend.delete_object(key)
+
+        # Invalidate CDN cache
+        if success and self.config.cdn_domain:
+            self.cdn.invalidate_cache([key])
+
+        return success
+
+    def list(self, prefix: str = "", max_keys: int = 1000) -> List[ObjectMetadata]:
+        """
+        List objects
+
+        Args:
+            prefix: Key prefix filter
+            max_keys: Maximum results
+
+        Returns:
+            List of ObjectMetadata
+        """
+        objects = self.backend.list_objects(prefix, max_keys)
+
+        # Add CDN URLs if configured
+        if self.config.cdn_domain:
+            for obj in objects:
+                obj.cdn_url = self.cdn.get_cdn_url(obj.key)
+
+        return objects
+
+    def exists(self, key: str) -> bool:
+        """Check if object exists"""
+        return self.backend.object_exists(key)
+
+    def generate_signed_url(
+        self,
+        key: str,
+        expires_in: int = 3600,
+        content_type: Optional[str] = None
+    ) -> str:
+        """
+        Generate signed URL for secure access
+
+        Args:
+            key: Object key
+            expires_in: Expiration time in seconds
+            content_type: Expected content type
+
+        Returns:
+            Signed URL
+        """
+        base_url = f"https://{self.config.cdn_domain}" if self.config.cdn_domain else "http://localhost"
+
+        config = SignedUrlConfig(
+            expires_in_seconds=expires_in,
+            content_type=content_type
+        )
+
+        return self.url_signer.generate_signed_url(base_url, key, config)
+
+    def verify_signed_url(
+        self,
+        key: str,
+        signature: str,
+        expires: int,
+        content_type: Optional[str] = None
+    ) -> bool:
+        """Verify signed URL"""
+        return self.url_signer.verify_signed_url(key, signature, expires, content_type)
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get storage statistics"""
+        objects = self.list()
+
+        total_size = sum(obj.size_bytes for obj in objects)
+        total_count = len(objects)
+
+        # Group by content type
+        by_type = {}
+        for obj in objects:
+            ct = obj.content_type
+            if ct not in by_type:
+                by_type[ct] = {'count': 0, 'size_bytes': 0}
+            by_type[ct]['count'] += 1
+            by_type[ct]['size_bytes'] += obj.size_bytes
+
+        return {
+            'total_objects': total_count,
+            'total_size_bytes': total_size,
+            'total_size_mb': round(total_size / (1024 * 1024), 2),
+            'by_content_type': by_type,
+            'backend': self.config.backend.value,
+            'cdn_enabled': self.config.cdn_domain is not None
+        }
+
+
+if __name__ == '__main__':
+    print("Object Storage + CDN Module")
+    print("=" * 60)
+
+    # Example usage
+    config = StorageConfig(
+        backend=StorageBackend.LOCAL,
+        bucket_name="test-bucket",
+        base_path="./test_storage",
+        cdn_domain="cdn.example.com"
+    )
+
+    manager = StorageManager(config, signing_secret="test-secret")
+
+    print(f"Storage backend: {config.backend.value}")
+    print(f"CDN domain: {config.cdn_domain}")

--- a/test_analytics.py
+++ b/test_analytics.py
@@ -1,0 +1,445 @@
+"""
+Tests for Analytics Module
+Issue: #33
+"""
+import pytest
+from analytics import AnalyticsTracker, EventType, Platform
+from datetime import datetime, timedelta
+
+
+class TestAnalyticsTracker:
+    """Test cases for AnalyticsTracker class"""
+
+    def test_initialization(self):
+        """Test that tracker initializes correctly"""
+        tracker = AnalyticsTracker()
+        assert tracker._events == []
+        assert tracker._metrics_cache == {}
+
+    def test_track_view_event(self):
+        """Test tracking a view event"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event("asset1", EventType.VIEW)
+
+        assert event["asset_id"] == "asset1"
+        assert event["event_type"] == "view"
+        assert event["platform"] == "web"
+        assert "timestamp" in event
+
+    def test_track_play_event(self):
+        """Test tracking a play event"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event("asset2", EventType.PLAY, Platform.SLACK)
+
+        assert event["asset_id"] == "asset2"
+        assert event["event_type"] == "play"
+        assert event["platform"] == "slack"
+
+    def test_track_click_event(self):
+        """Test tracking a click event"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event("asset3", EventType.CLICK, Platform.DISCORD)
+
+        assert event["asset_id"] == "asset3"
+        assert event["event_type"] == "click"
+        assert event["platform"] == "discord"
+
+    def test_track_event_with_short_code(self):
+        """Test tracking event with short code"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event(
+            "asset4",
+            EventType.VIEW,
+            short_code="abc123"
+        )
+
+        assert event["short_code"] == "abc123"
+
+    def test_track_event_with_metadata(self):
+        """Test tracking event with additional metadata"""
+        tracker = AnalyticsTracker()
+        metadata = {"user_agent": "Mozilla/5.0", "referrer": "https://example.com"}
+        event = tracker.track_event(
+            "asset5",
+            EventType.VIEW,
+            metadata=metadata
+        )
+
+        assert event["metadata"]["user_agent"] == "Mozilla/5.0"
+        assert event["metadata"]["referrer"] == "https://example.com"
+
+
+class TestAssetMetrics:
+    """Test cases for asset metrics aggregation"""
+
+    def test_get_asset_metrics_no_events(self):
+        """Test getting metrics for asset with no events"""
+        tracker = AnalyticsTracker()
+        metrics = tracker.get_asset_metrics("nonexistent")
+
+        assert metrics["asset_id"] == "nonexistent"
+        assert metrics["views"] == 0
+        assert metrics["plays"] == 0
+        assert metrics["clicks"] == 0
+        assert metrics["ctr"] == 0.0
+
+    def test_get_asset_metrics_single_view(self):
+        """Test metrics with single view"""
+        tracker = AnalyticsTracker()
+        tracker.track_event("asset1", EventType.VIEW)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 1
+        assert metrics["plays"] == 0
+        assert metrics["clicks"] == 0
+        assert metrics["ctr"] == 0.0
+
+    def test_get_asset_metrics_ctr_calculation(self):
+        """Test CTR calculation"""
+        tracker = AnalyticsTracker()
+
+        # 10 views, 2 clicks = 20% CTR
+        for _ in range(10):
+            tracker.track_event("asset1", EventType.VIEW)
+        for _ in range(2):
+            tracker.track_event("asset1", EventType.CLICK)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 10
+        assert metrics["clicks"] == 2
+        assert metrics["ctr"] == 20.0
+
+    def test_get_asset_metrics_play_rate(self):
+        """Test play rate calculation"""
+        tracker = AnalyticsTracker()
+
+        # 100 views, 75 plays = 75% play rate
+        for _ in range(100):
+            tracker.track_event("asset1", EventType.VIEW)
+        for _ in range(75):
+            tracker.track_event("asset1", EventType.PLAY)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 100
+        assert metrics["plays"] == 75
+        assert metrics["play_rate"] == 75.0
+
+    def test_get_asset_metrics_mixed_events(self):
+        """Test metrics with mixed event types"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset1", EventType.PLAY)
+        tracker.track_event("asset1", EventType.PLAY)
+        tracker.track_event("asset1", EventType.CLICK)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 3
+        assert metrics["plays"] == 2
+        assert metrics["clicks"] == 1
+        assert metrics["ctr"] == 33.33
+        assert metrics["play_rate"] == 66.67
+
+    def test_metrics_cache_invalidation(self):
+        """Test that cache is invalidated when new events are tracked"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+        metrics1 = tracker.get_asset_metrics("asset1")
+        assert metrics1["views"] == 1
+
+        # Add another event
+        tracker.track_event("asset1", EventType.VIEW)
+        metrics2 = tracker.get_asset_metrics("asset1")
+        assert metrics2["views"] == 2
+
+
+class TestPlatformMetrics:
+    """Test cases for platform-specific metrics"""
+
+    def test_get_platform_metrics_single_platform(self):
+        """Test platform metrics with events from one platform"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW, Platform.SLACK)
+        tracker.track_event("asset1", EventType.PLAY, Platform.SLACK)
+        tracker.track_event("asset1", EventType.CLICK, Platform.SLACK)
+
+        platform_metrics = tracker.get_platform_metrics("asset1")
+
+        assert "slack" in platform_metrics
+        assert platform_metrics["slack"]["views"] == 1
+        assert platform_metrics["slack"]["plays"] == 1
+        assert platform_metrics["slack"]["clicks"] == 1
+        assert platform_metrics["slack"]["ctr"] == 100.0
+
+    def test_get_platform_metrics_multiple_platforms(self):
+        """Test platform metrics across multiple platforms"""
+        tracker = AnalyticsTracker()
+
+        # Slack: 10 views, 2 clicks
+        for _ in range(10):
+            tracker.track_event("asset1", EventType.VIEW, Platform.SLACK)
+        for _ in range(2):
+            tracker.track_event("asset1", EventType.CLICK, Platform.SLACK)
+
+        # Discord: 5 views, 1 click
+        for _ in range(5):
+            tracker.track_event("asset1", EventType.VIEW, Platform.DISCORD)
+        tracker.track_event("asset1", EventType.CLICK, Platform.DISCORD)
+
+        platform_metrics = tracker.get_platform_metrics("asset1")
+
+        assert platform_metrics["slack"]["views"] == 10
+        assert platform_metrics["slack"]["clicks"] == 2
+        assert platform_metrics["slack"]["ctr"] == 20.0
+
+        assert platform_metrics["discord"]["views"] == 5
+        assert platform_metrics["discord"]["clicks"] == 1
+        assert platform_metrics["discord"]["ctr"] == 20.0
+
+    def test_get_platform_metrics_no_events(self):
+        """Test platform metrics with no events"""
+        tracker = AnalyticsTracker()
+        platform_metrics = tracker.get_platform_metrics("nonexistent")
+
+        assert platform_metrics == {}
+
+
+class TestShortLinkMetrics:
+    """Test cases for short link metrics"""
+
+    def test_get_short_link_metrics_no_events(self):
+        """Test short link metrics with no events"""
+        tracker = AnalyticsTracker()
+        metrics = tracker.get_short_link_metrics("unknown")
+
+        assert metrics["short_code"] == "unknown"
+        assert metrics["views"] == 0
+        assert metrics["clicks"] == 0
+
+    def test_get_short_link_metrics_with_events(self):
+        """Test short link metrics with tracked events"""
+        tracker = AnalyticsTracker()
+
+        # Track events with short code
+        for _ in range(5):
+            tracker.track_event("asset1", EventType.VIEW, short_code="abc123")
+        for _ in range(3):
+            tracker.track_event("asset1", EventType.PLAY, short_code="abc123")
+        tracker.track_event("asset1", EventType.CLICK, short_code="abc123")
+
+        metrics = tracker.get_short_link_metrics("abc123")
+
+        assert metrics["short_code"] == "abc123"
+        assert metrics["asset_id"] == "asset1"
+        assert metrics["views"] == 5
+        assert metrics["plays"] == 3
+        assert metrics["clicks"] == 1
+        assert metrics["ctr"] == 20.0
+        assert metrics["play_rate"] == 60.0
+
+    def test_get_short_link_metrics_multiple_links(self):
+        """Test metrics are separate for different short links"""
+        tracker = AnalyticsTracker()
+
+        # Link 1
+        tracker.track_event("asset1", EventType.VIEW, short_code="link1")
+        tracker.track_event("asset1", EventType.CLICK, short_code="link1")
+
+        # Link 2
+        tracker.track_event("asset1", EventType.VIEW, short_code="link2")
+        tracker.track_event("asset1", EventType.VIEW, short_code="link2")
+
+        metrics1 = tracker.get_short_link_metrics("link1")
+        metrics2 = tracker.get_short_link_metrics("link2")
+
+        assert metrics1["views"] == 1
+        assert metrics1["clicks"] == 1
+        assert metrics2["views"] == 2
+        assert metrics2["clicks"] == 0
+
+
+class TestTopAssets:
+    """Test cases for top assets ranking"""
+
+    def test_get_top_assets_by_views(self):
+        """Test getting top assets by views"""
+        tracker = AnalyticsTracker()
+
+        # Asset 1: 10 views
+        for _ in range(10):
+            tracker.track_event("asset1", EventType.VIEW)
+
+        # Asset 2: 5 views
+        for _ in range(5):
+            tracker.track_event("asset2", EventType.VIEW)
+
+        # Asset 3: 15 views
+        for _ in range(15):
+            tracker.track_event("asset3", EventType.VIEW)
+
+        top_assets = tracker.get_top_assets(metric="views", limit=10)
+
+        assert len(top_assets) == 3
+        assert top_assets[0]["asset_id"] == "asset3"
+        assert top_assets[0]["views"] == 15
+        assert top_assets[1]["asset_id"] == "asset1"
+        assert top_assets[2]["asset_id"] == "asset2"
+
+    def test_get_top_assets_by_ctr(self):
+        """Test getting top assets by CTR"""
+        tracker = AnalyticsTracker()
+
+        # Asset 1: 10 views, 5 clicks = 50% CTR
+        for _ in range(10):
+            tracker.track_event("asset1", EventType.VIEW)
+        for _ in range(5):
+            tracker.track_event("asset1", EventType.CLICK)
+
+        # Asset 2: 10 views, 1 click = 10% CTR
+        for _ in range(10):
+            tracker.track_event("asset2", EventType.VIEW)
+        tracker.track_event("asset2", EventType.CLICK)
+
+        top_assets = tracker.get_top_assets(metric="ctr", limit=10)
+
+        assert top_assets[0]["asset_id"] == "asset1"
+        assert top_assets[0]["ctr"] == 50.0
+        assert top_assets[1]["asset_id"] == "asset2"
+        assert top_assets[1]["ctr"] == 10.0
+
+    def test_get_top_assets_limit(self):
+        """Test that limit parameter works"""
+        tracker = AnalyticsTracker()
+
+        # Create 10 assets
+        for i in range(10):
+            tracker.track_event(f"asset{i}", EventType.VIEW)
+
+        top_assets = tracker.get_top_assets(metric="views", limit=3)
+        assert len(top_assets) == 3
+
+
+class TestTimeframeQueries:
+    """Test cases for timeframe-based queries"""
+
+    def test_get_events_by_timeframe_no_filter(self):
+        """Test getting all events without timeframe filter"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset1", EventType.PLAY)
+
+        events = tracker.get_events_by_timeframe("asset1")
+        assert len(events) == 2
+
+    def test_get_events_by_timeframe_start_time(self):
+        """Test filtering events by start time"""
+        tracker = AnalyticsTracker()
+
+        # Track events
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset1", EventType.PLAY)
+
+        # Get events from now onwards (should include all)
+        now = datetime.utcnow()
+        past = now - timedelta(hours=1)
+
+        events = tracker.get_events_by_timeframe("asset1", start_time=past)
+        assert len(events) == 2
+
+    def test_get_events_by_timeframe_end_time(self):
+        """Test filtering events by end time"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+
+        # Get events until now (should include all)
+        now = datetime.utcnow()
+        future = now + timedelta(hours=1)
+
+        events = tracker.get_events_by_timeframe("asset1", end_time=future)
+        assert len(events) == 1
+
+
+class TestUtilityFunctions:
+    """Test utility functions"""
+
+    def test_clear_events_all(self):
+        """Test clearing all events"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset2", EventType.VIEW)
+
+        assert len(tracker._events) == 2
+
+        tracker.clear_events()
+        assert len(tracker._events) == 0
+
+    def test_clear_events_specific_asset(self):
+        """Test clearing events for specific asset"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+        tracker.track_event("asset2", EventType.VIEW)
+        tracker.track_event("asset1", EventType.PLAY)
+
+        tracker.clear_events(asset_id="asset1")
+
+        assert len(tracker._events) == 1
+        assert tracker._events[0]["asset_id"] == "asset2"
+
+    def test_clear_events_invalidates_cache(self):
+        """Test that clearing events invalidates cache"""
+        tracker = AnalyticsTracker()
+
+        tracker.track_event("asset1", EventType.VIEW)
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 1
+
+        tracker.clear_events(asset_id="asset1")
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 0
+
+
+class TestIntegration:
+    """Integration tests combining multiple features"""
+
+    def test_full_analytics_workflow(self):
+        """Test complete analytics workflow"""
+        tracker = AnalyticsTracker()
+
+        # Simulate user interactions across platforms
+        tracker.track_event("asset1", EventType.VIEW, Platform.SLACK, short_code="link1")
+        tracker.track_event("asset1", EventType.PLAY, Platform.SLACK, short_code="link1")
+        tracker.track_event("asset1", EventType.VIEW, Platform.DISCORD, short_code="link2")
+        tracker.track_event("asset1", EventType.VIEW, Platform.WEB)
+        tracker.track_event("asset1", EventType.CLICK, Platform.SLACK, short_code="link1")
+
+        # Check overall metrics
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["views"] == 3
+        assert metrics["plays"] == 1
+        assert metrics["clicks"] == 1
+
+        # Check platform breakdown
+        platform_metrics = tracker.get_platform_metrics("asset1")
+        assert platform_metrics["slack"]["views"] == 1
+        assert platform_metrics["slack"]["plays"] == 1
+        assert platform_metrics["slack"]["clicks"] == 1
+        assert platform_metrics["discord"]["views"] == 1
+        assert platform_metrics["web"]["views"] == 1
+
+        # Check short link metrics
+        link1_metrics = tracker.get_short_link_metrics("link1")
+        assert link1_metrics["views"] == 1
+        assert link1_metrics["plays"] == 1
+        assert link1_metrics["clicks"] == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_cdn.py
+++ b/test_cdn.py
@@ -1,0 +1,492 @@
+"""
+Comprehensive tests for CDN module
+Tests cache headers, Range requests, and signed URLs
+"""
+import pytest
+from datetime import datetime, timedelta
+from urllib.parse import urlparse, parse_qs
+import time
+
+from cdn import (
+    CachePolicy,
+    RangeRequest,
+    SignedURL,
+    CDNHelper
+)
+
+
+class TestCachePolicy:
+    """Test cache policy header generation"""
+
+    def test_long_cache_public(self):
+        """Test long cache policy with public caching"""
+        headers = CachePolicy.get_headers(
+            cache_duration=CachePolicy.LONG_CACHE,
+            is_immutable=False,
+            is_private=False
+        )
+
+        assert "Cache-Control" in headers
+        assert "public" in headers["Cache-Control"]
+        assert "max-age=86400" in headers["Cache-Control"]
+        assert "Expires" in headers
+
+    def test_immutable_cache(self):
+        """Test immutable cache policy"""
+        headers = CachePolicy.get_headers(
+            cache_duration=CachePolicy.IMMUTABLE_CACHE,
+            is_immutable=True
+        )
+
+        assert "immutable" in headers["Cache-Control"]
+        assert "max-age=31536000" in headers["Cache-Control"]
+
+    def test_private_cache(self):
+        """Test private cache policy"""
+        headers = CachePolicy.get_headers(
+            cache_duration=3600,
+            is_private=True
+        )
+
+        assert "private" in headers["Cache-Control"]
+        assert "public" not in headers["Cache-Control"]
+
+    def test_no_cache(self):
+        """Test no-cache policy"""
+        headers = CachePolicy.get_headers(cache_duration=0)
+
+        assert "no-cache" in headers["Cache-Control"]
+        assert "no-store" in headers["Cache-Control"]
+        assert "must-revalidate" in headers["Cache-Control"]
+        assert headers["Expires"] == "0"
+        assert "Pragma" in headers
+
+    def test_short_cache(self):
+        """Test short cache policy"""
+        headers = CachePolicy.get_headers(cache_duration=CachePolicy.SHORT_CACHE)
+
+        assert "max-age=3600" in headers["Cache-Control"]
+
+    def test_expires_header_format(self):
+        """Test that Expires header has correct format"""
+        headers = CachePolicy.get_headers(cache_duration=3600)
+
+        # Should be in HTTP date format
+        expires = headers["Expires"]
+        assert "GMT" in expires
+        # Parse to verify it's valid
+        datetime.strptime(expires, "%a, %d %b %Y %H:%M:%S GMT")
+
+
+class TestRangeRequest:
+    """Test HTTP Range request parsing and headers"""
+
+    def test_parse_full_range(self):
+        """Test parsing a full range specification"""
+        result = RangeRequest.parse_range_header("bytes=0-1023", 2048)
+
+        assert result == (0, 1023)
+
+    def test_parse_range_from_start(self):
+        """Test parsing range from start to end"""
+        result = RangeRequest.parse_range_header("bytes=1024-", 2048)
+
+        assert result == (1024, 2047)
+
+    def test_parse_suffix_range(self):
+        """Test parsing suffix range (last N bytes)"""
+        result = RangeRequest.parse_range_header("bytes=-500", 2048)
+
+        assert result == (1548, 2047)
+
+    def test_parse_invalid_range(self):
+        """Test invalid range returns None"""
+        assert RangeRequest.parse_range_header("bytes=2000-1000", 2048) is None
+        assert RangeRequest.parse_range_header("bytes=5000-6000", 2048) is None
+        assert RangeRequest.parse_range_header("invalid", 2048) is None
+        assert RangeRequest.parse_range_header("bytes=", 2048) is None
+
+    def test_parse_no_range_header(self):
+        """Test that missing range header returns None"""
+        assert RangeRequest.parse_range_header("", 2048) is None
+        assert RangeRequest.parse_range_header(None, 2048) is None
+
+    def test_parse_multipart_range_uses_first(self):
+        """Test that multipart ranges use only the first range"""
+        result = RangeRequest.parse_range_header("bytes=0-100,200-300", 2048)
+
+        assert result == (0, 100)
+
+    def test_get_range_response_headers(self):
+        """Test range response header generation"""
+        headers = RangeRequest.get_range_response_headers(
+            start=0,
+            end=1023,
+            total_length=2048,
+            content_type="image/gif"
+        )
+
+        assert headers["Content-Type"] == "image/gif"
+        assert headers["Content-Length"] == "1024"
+        assert headers["Content-Range"] == "bytes 0-1023/2048"
+        assert headers["Accept-Ranges"] == "bytes"
+
+    def test_get_full_response_headers(self):
+        """Test full content response headers"""
+        headers = RangeRequest.get_full_response_headers(
+            total_length=2048,
+            content_type="video/mp4"
+        )
+
+        assert headers["Content-Type"] == "video/mp4"
+        assert headers["Content-Length"] == "2048"
+        assert headers["Accept-Ranges"] == "bytes"
+
+    def test_range_boundary_conditions(self):
+        """Test range parsing at boundaries"""
+        # First byte only
+        assert RangeRequest.parse_range_header("bytes=0-0", 2048) == (0, 0)
+
+        # Last byte only
+        assert RangeRequest.parse_range_header("bytes=2047-2047", 2048) == (2047, 2047)
+
+        # Entire content
+        assert RangeRequest.parse_range_header("bytes=0-2047", 2048) == (0, 2047)
+
+    def test_range_edge_cases(self):
+        """Test edge cases in range parsing"""
+        # Negative start
+        assert RangeRequest.parse_range_header("bytes=-1-100", 2048) is None
+
+        # End beyond content length
+        assert RangeRequest.parse_range_header("bytes=0-3000", 2048) is None
+
+        # Empty range
+        assert RangeRequest.parse_range_header("bytes=-", 2048) is None
+
+
+class TestSignedURL:
+    """Test signed URL generation and validation"""
+
+    def test_generate_signed_url(self):
+        """Test basic signed URL generation"""
+        signer = SignedURL("test-secret-key")
+        url = signer.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600
+        )
+
+        assert "expires=" in url
+        assert "signature=" in url
+        assert "https://cdn.example.com/assets/image.gif" in url
+
+    def test_validate_valid_url(self):
+        """Test validation of valid signed URL"""
+        signer = SignedURL("test-secret-key")
+        signed_url = signer.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600
+        )
+
+        is_valid, error = signer.validate_signed_url(signed_url)
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_expired_url(self):
+        """Test validation of expired URL"""
+        signer = SignedURL("test-secret-key")
+
+        # Create URL that expires in 1 second
+        signed_url = signer.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=1
+        )
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        is_valid, error = signer.validate_signed_url(signed_url)
+
+        assert is_valid is False
+        assert "expired" in error.lower()
+
+    def test_validate_tampered_signature(self):
+        """Test validation detects tampered signature"""
+        signer = SignedURL("test-secret-key")
+        signed_url = signer.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600
+        )
+
+        # Tamper with the signature
+        tampered_url = signed_url.replace("signature=", "signature=tampered")
+
+        is_valid, error = signer.validate_signed_url(tampered_url)
+
+        assert is_valid is False
+        assert "signature" in error.lower()
+
+    def test_validate_missing_signature(self):
+        """Test validation detects missing signature"""
+        signer = SignedURL("test-secret-key")
+
+        is_valid, error = signer.validate_signed_url(
+            "https://cdn.example.com/assets/image.gif?expires=12345"
+        )
+
+        assert is_valid is False
+        assert "signature" in error.lower()
+
+    def test_validate_missing_expiration(self):
+        """Test validation detects missing expiration"""
+        signer = SignedURL("test-secret-key")
+
+        is_valid, error = signer.validate_signed_url(
+            "https://cdn.example.com/assets/image.gif?signature=abc123"
+        )
+
+        assert is_valid is False
+        assert "expiration" in error.lower()
+
+    def test_different_keys_produce_different_signatures(self):
+        """Test that different keys produce different signatures"""
+        signer1 = SignedURL("key1")
+        signer2 = SignedURL("key2")
+
+        url1 = signer1.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600
+        )
+        url2 = signer2.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600
+        )
+
+        # Extract signatures
+        sig1 = parse_qs(urlparse(url1).query)["signature"][0]
+        sig2 = parse_qs(urlparse(url2).query)["signature"][0]
+
+        assert sig1 != sig2
+
+    def test_wrong_key_fails_validation(self):
+        """Test that wrong key fails validation"""
+        signer1 = SignedURL("correct-key")
+        signer2 = SignedURL("wrong-key")
+
+        signed_url = signer1.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600
+        )
+
+        is_valid, error = signer2.validate_signed_url(signed_url)
+
+        assert is_valid is False
+
+    def test_additional_params(self):
+        """Test signed URL with additional parameters"""
+        signer = SignedURL("test-secret-key")
+        url = signer.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif",
+            expiration_seconds=3600,
+            additional_params={"width": "500", "quality": "high"}
+        )
+
+        assert "width=500" in url
+        assert "quality=high" in url
+
+        # Should still validate
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_empty_secret_key_raises_error(self):
+        """Test that empty secret key raises error"""
+        with pytest.raises(ValueError, match="Secret key cannot be empty"):
+            SignedURL("")
+
+    def test_url_with_existing_params(self):
+        """Test signing URL that already has query parameters"""
+        signer = SignedURL("test-secret-key")
+        url = signer.generate_signed_url(
+            "https://cdn.example.com/assets/image.gif?version=2",
+            expiration_seconds=3600
+        )
+
+        assert "version=2" in url
+        assert "expires=" in url
+        assert "signature=" in url
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+
+class TestCDNHelper:
+    """Test unified CDN helper functionality"""
+
+    def test_get_asset_headers_full_content(self):
+        """Test getting headers for full content delivery"""
+        helper = CDNHelper()
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="image/gif",
+            content_length=2048
+        )
+
+        assert status == 200
+        assert range_spec is None
+        assert headers["Content-Type"] == "image/gif"
+        assert headers["Content-Length"] == "2048"
+        assert "Cache-Control" in headers
+
+    def test_get_asset_headers_with_range(self):
+        """Test getting headers for range request"""
+        helper = CDNHelper()
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="video/mp4",
+            content_length=4096,
+            range_header="bytes=0-1023"
+        )
+
+        assert status == 206  # Partial Content
+        assert range_spec == (0, 1023)
+        assert headers["Content-Type"] == "video/mp4"
+        assert headers["Content-Length"] == "1024"
+        assert headers["Content-Range"] == "bytes 0-1023/4096"
+
+    def test_get_asset_headers_immutable(self):
+        """Test getting headers for immutable content"""
+        helper = CDNHelper()
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="image/gif",
+            content_length=2048,
+            is_immutable=True,
+            cache_duration=CachePolicy.IMMUTABLE_CACHE
+        )
+
+        assert "immutable" in headers["Cache-Control"]
+        assert "max-age=31536000" in headers["Cache-Control"]
+
+    def test_create_signed_url(self):
+        """Test creating signed URL through helper"""
+        helper = CDNHelper(secret_key="test-key")
+        url = helper.create_signed_asset_url(
+            "https://cdn.example.com/asset.gif",
+            expiration_seconds=1800
+        )
+
+        assert "signature=" in url
+        assert "expires=" in url
+
+    def test_create_signed_url_without_key_raises_error(self):
+        """Test that creating signed URL without key raises error"""
+        helper = CDNHelper()  # No secret key
+
+        with pytest.raises(ValueError, match="not configured"):
+            helper.create_signed_asset_url("https://cdn.example.com/asset.gif")
+
+    def test_validate_url(self):
+        """Test validating signed URL through helper"""
+        helper = CDNHelper(secret_key="test-key")
+        url = helper.create_signed_asset_url(
+            "https://cdn.example.com/asset.gif"
+        )
+
+        is_valid, error = helper.validate_asset_url(url)
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_url_without_key_raises_error(self):
+        """Test that validating URL without key raises error"""
+        helper = CDNHelper()  # No secret key
+
+        with pytest.raises(ValueError, match="not configured"):
+            helper.validate_asset_url("https://cdn.example.com/asset.gif?signature=abc")
+
+    def test_invalid_range_returns_full_content(self):
+        """Test that invalid range request returns full content"""
+        helper = CDNHelper()
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="image/gif",
+            content_length=2048,
+            range_header="bytes=5000-6000"  # Invalid range
+        )
+
+        assert status == 200  # Full content, not 206
+        assert range_spec is None
+        assert headers["Content-Length"] == "2048"
+
+
+class TestIntegration:
+    """Integration tests combining multiple components"""
+
+    def test_full_cdn_workflow(self):
+        """Test complete CDN workflow with signed URL and range request"""
+        # Initialize helper
+        helper = CDNHelper(secret_key="integration-test-key")
+
+        # Create signed URL
+        signed_url = helper.create_signed_asset_url(
+            "https://cdn.example.com/large-video.mp4",
+            expiration_seconds=3600
+        )
+
+        # Validate URL
+        is_valid, error = helper.validate_asset_url(signed_url)
+        assert is_valid is True
+
+        # Get headers for range request
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="video/mp4",
+            content_length=10485760,  # 10MB
+            range_header="bytes=0-1048575",  # First 1MB
+            cache_duration=CachePolicy.LONG_CACHE
+        )
+
+        assert status == 206
+        assert range_spec == (0, 1048575)
+        assert headers["Content-Range"] == "bytes 0-1048575/10485760"
+        assert "Cache-Control" in headers
+
+    def test_immutable_asset_with_signed_url(self):
+        """Test serving immutable asset with signed URL"""
+        helper = CDNHelper(secret_key="test-key")
+
+        # Create signed URL for immutable asset
+        url = helper.create_signed_asset_url(
+            "https://cdn.example.com/static/logo-v2.gif",
+            expiration_seconds=31536000  # 1 year
+        )
+
+        # Get headers with immutable cache
+        headers, _, status = helper.get_asset_headers(
+            content_type="image/gif",
+            content_length=4096,
+            is_immutable=True,
+            cache_duration=CachePolicy.IMMUTABLE_CACHE
+        )
+
+        assert status == 200
+        assert "immutable" in headers["Cache-Control"]
+        assert "max-age=31536000" in headers["Cache-Control"]
+
+    def test_progressive_video_loading(self):
+        """Test progressive video loading with range requests"""
+        helper = CDNHelper()
+
+        # Simulate video player requesting chunks
+        content_length = 20971520  # 20MB video
+        chunk_size = 1048576  # 1MB chunks
+
+        for i in range(3):
+            start = i * chunk_size
+            end = start + chunk_size - 1
+
+            headers, range_spec, status = helper.get_asset_headers(
+                content_type="video/mp4",
+                content_length=content_length,
+                range_header=f"bytes={start}-{end}"
+            )
+
+            assert status == 206
+            assert range_spec == (start, end)
+            assert int(headers["Content-Length"]) == chunk_size

--- a/test_cdn_edge_cases.py
+++ b/test_cdn_edge_cases.py
@@ -1,0 +1,483 @@
+"""
+Additional edge case tests for CDN module
+Focuses on uncovered edge cases and error conditions
+"""
+import pytest
+from datetime import datetime, timedelta
+import time
+
+from cdn import (
+    CachePolicy,
+    RangeRequest,
+    SignedURL,
+    CDNHelper
+)
+
+
+class TestCachePolicyEdgeCases:
+    """Additional cache policy edge cases"""
+
+    def test_negative_cache_duration(self):
+        """Test behavior with negative cache duration"""
+        # Current implementation allows negative, documents actual behavior
+        headers = CachePolicy.get_headers(cache_duration=-1)
+        # Negative duration is allowed in current implementation
+        assert "max-age=-1" in headers["Cache-Control"] or "no-cache" in headers["Cache-Control"]
+
+    def test_very_long_cache_duration(self):
+        """Test with extremely long cache duration"""
+        ten_years = 10 * 365 * 24 * 60 * 60
+        headers = CachePolicy.get_headers(cache_duration=ten_years)
+        assert f"max-age={ten_years}" in headers["Cache-Control"]
+
+    def test_cache_private_with_immutable(self):
+        """Test combining private and immutable flags"""
+        headers = CachePolicy.get_headers(
+            cache_duration=3600,
+            is_private=True,
+            is_immutable=True
+        )
+        assert "private" in headers["Cache-Control"]
+        assert "immutable" in headers["Cache-Control"]
+        assert "public" not in headers["Cache-Control"]
+
+    def test_expires_header_future_date(self):
+        """Test Expires header is properly formatted for future dates"""
+        headers = CachePolicy.get_headers(cache_duration=7200)
+        expires = headers["Expires"]
+
+        # Parse and verify it's in the future
+        expires_time = datetime.strptime(expires, "%a, %d %b %Y %H:%M:%S GMT")
+        assert expires_time > datetime.utcnow()
+
+
+class TestRangeRequestEdgeCases:
+    """Additional range request edge cases"""
+
+    def test_range_single_byte(self):
+        """Test requesting exactly one byte"""
+        result = RangeRequest.parse_range_header("bytes=100-100", 1000)
+        assert result == (100, 100)
+
+    def test_range_entire_file_explicit(self):
+        """Test requesting entire file with explicit range"""
+        result = RangeRequest.parse_range_header("bytes=0-999", 1000)
+        assert result == (0, 999)
+
+    def test_range_missing_bytes_prefix(self):
+        """Test range header without 'bytes=' prefix"""
+        result = RangeRequest.parse_range_header("0-100", 1000)
+        assert result is None
+
+    def test_range_with_whitespace(self):
+        """Test range header with whitespace"""
+        result = RangeRequest.parse_range_header("bytes= 0-100", 1000)
+        # Should fail due to whitespace in parsing
+        assert result is None or result == (0, 100)
+
+    def test_suffix_range_larger_than_file(self):
+        """Test suffix range requesting more bytes than file has"""
+        result = RangeRequest.parse_range_header("bytes=-5000", 1000)
+        # Should return from start of file
+        assert result == (0, 999)
+
+    def test_range_negative_end(self):
+        """Test range with negative end position"""
+        result = RangeRequest.parse_range_header("bytes=0--5", 1000)
+        assert result is None
+
+    def test_range_malformed_multiple_dashes(self):
+        """Test malformed range with multiple dashes"""
+        result = RangeRequest.parse_range_header("bytes=100-200-300", 1000)
+        # Should either fail or parse first part
+        assert result is None or result == (100, 200)
+
+    def test_range_with_letters(self):
+        """Test range with non-numeric characters"""
+        assert RangeRequest.parse_range_header("bytes=abc-def", 1000) is None
+        assert RangeRequest.parse_range_header("bytes=100-xyz", 1000) is None
+
+    def test_get_range_response_headers_zero_length(self):
+        """Test range response for zero-length content"""
+        headers = RangeRequest.get_range_response_headers(
+            start=0,
+            end=0,
+            total_length=1,
+            content_type="application/octet-stream"
+        )
+        assert headers["Content-Length"] == "1"
+        assert headers["Content-Range"] == "bytes 0-0/1"
+
+    def test_range_at_exact_boundary(self):
+        """Test range at exact file boundary"""
+        content_length = 1024
+        # Last byte
+        result = RangeRequest.parse_range_header(
+            f"bytes={content_length-1}-{content_length-1}",
+            content_length
+        )
+        assert result == (content_length-1, content_length-1)
+
+    def test_range_exceeds_by_one(self):
+        """Test range that exceeds file size by exactly one byte"""
+        result = RangeRequest.parse_range_header("bytes=0-1024", 1024)
+        # End is 1024 but file is 1024 bytes (0-1023), should fail
+        assert result is None
+
+
+class TestSignedURLEdgeCases:
+    """Additional signed URL edge cases"""
+
+    def test_empty_base_url(self):
+        """Test signed URL with minimal base URL"""
+        signer = SignedURL("secret")
+        url = signer.generate_signed_url("https://x.co/a")
+        assert "expires=" in url
+        assert "signature=" in url
+
+    def test_url_with_port(self):
+        """Test signing URL with port number"""
+        signer = SignedURL("secret")
+        url = signer.generate_signed_url("https://localhost:8080/asset.gif")
+        assert "localhost:8080" in url
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_url_with_fragment(self):
+        """Test signing URL with fragment"""
+        signer = SignedURL("secret")
+        url = signer.generate_signed_url("https://cdn.com/asset.gif#metadata")
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_very_short_expiration(self):
+        """Test URL with very short expiration (edge of immediate expiry)"""
+        signer = SignedURL("secret")
+        # 0 seconds means it might be expired immediately
+        url = signer.generate_signed_url(
+            "https://cdn.com/asset.gif",
+            expiration_seconds=0
+        )
+
+        # Might be valid or expired depending on timing
+        is_valid, error = signer.validate_signed_url(url)
+        # Either valid or expired is acceptable
+
+    def test_very_long_expiration(self):
+        """Test URL with very long expiration"""
+        signer = SignedURL("secret")
+        ten_years = 10 * 365 * 24 * 60 * 60
+        url = signer.generate_signed_url(
+            "https://cdn.com/asset.gif",
+            expiration_seconds=ten_years
+        )
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_signature_with_special_chars_in_url(self):
+        """Test signing URL with special characters"""
+        signer = SignedURL("secret-key-123")
+        url = signer.generate_signed_url(
+            "https://cdn.com/path/to/asset-name_v2.gif"
+        )
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_additional_params_override_attempt(self):
+        """Test that additional params can't override system params"""
+        signer = SignedURL("secret")
+
+        # Try to override expires in additional params
+        url = signer.generate_signed_url(
+            "https://cdn.com/asset.gif",
+            expiration_seconds=3600,
+            additional_params={"expires": "999999999"}  # Try to override
+        )
+
+        # The last one set will win (additional_params), which may break validation
+        # This documents actual behavior
+        assert "expires=" in url
+
+    def test_url_with_multiple_existing_params(self):
+        """Test signing URL with many existing parameters"""
+        signer = SignedURL("secret")
+        url = signer.generate_signed_url(
+            "https://cdn.com/a.gif?v=1&size=large&format=webp&quality=high"
+        )
+
+        assert "v=1" in url
+        assert "size=large" in url
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_validate_malformed_url(self):
+        """Test validation with malformed URL"""
+        signer = SignedURL("secret")
+
+        is_valid, error = signer.validate_signed_url("not-a-url")
+        # Should handle gracefully
+        assert is_valid is False
+
+    def test_validate_url_missing_both_params(self):
+        """Test validation with URL missing all required params"""
+        signer = SignedURL("secret")
+
+        is_valid, error = signer.validate_signed_url("https://cdn.com/asset.gif")
+        assert is_valid is False
+        assert error is not None
+
+    def test_signature_url_safe_base64(self):
+        """Test that signature is URL-safe base64"""
+        signer = SignedURL("secret")
+        url = signer.generate_signed_url("https://cdn.com/asset.gif")
+
+        # Extract signature
+        from urllib.parse import urlparse, parse_qs
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        signature = params["signature"][0]
+
+        # Should not contain +, /, or =
+        assert "+" not in signature
+        assert "/" not in signature
+        # = is stripped
+
+    def test_bytes_secret_key(self):
+        """Test initializing with bytes secret key"""
+        signer = SignedURL(b"secret-bytes")
+        url = signer.generate_signed_url("https://cdn.com/asset.gif")
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_unicode_secret_key(self):
+        """Test secret key with unicode characters"""
+        signer = SignedURL("秘密キー🔐")
+        url = signer.generate_signed_url("https://cdn.com/asset.gif")
+
+        is_valid, error = signer.validate_signed_url(url)
+        assert is_valid is True
+
+    def test_validate_invalid_timestamp_format(self):
+        """Test validation with non-integer timestamp"""
+        signer = SignedURL("secret")
+
+        is_valid, error = signer.validate_signed_url(
+            "https://cdn.com/a.gif?expires=notanumber&signature=abc"
+        )
+        assert is_valid is False
+        assert "Invalid URL format" in error or "invalid" in error.lower()
+
+
+class TestCDNHelperEdgeCases:
+    """Additional CDN helper edge cases"""
+
+    def test_helper_without_secret_key(self):
+        """Test CDN helper initialized without secret key"""
+        helper = CDNHelper()
+        assert helper.signed_url_handler is None
+
+    def test_helper_with_empty_secret_key(self):
+        """Test CDN helper with empty secret key"""
+        # Empty string is allowed, error only raised when trying to use SignedURL
+        helper = CDNHelper(secret_key="")
+        # Should raise when trying to create signed URL
+        with pytest.raises(ValueError):
+            helper.create_signed_asset_url("https://cdn.com/asset.gif")
+
+    def test_get_asset_headers_zero_length_content(self):
+        """Test headers for zero-length content"""
+        helper = CDNHelper()
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="text/plain",
+            content_length=0
+        )
+
+        assert status == 200
+        assert headers["Content-Length"] == "0"
+
+    def test_get_asset_headers_very_large_content(self):
+        """Test headers for very large content (streaming case)"""
+        helper = CDNHelper()
+        large_size = 10 * 1024 * 1024 * 1024  # 10GB
+
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="video/mp4",
+            content_length=large_size
+        )
+
+        assert headers["Content-Length"] == str(large_size)
+        assert "Accept-Ranges" in headers
+
+    def test_get_asset_headers_range_boundary(self):
+        """Test range request at exact content boundary"""
+        helper = CDNHelper()
+        content_length = 1000
+
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="image/gif",
+            content_length=content_length,
+            range_header=f"bytes=0-{content_length-1}"
+        )
+
+        assert status == 206
+        assert range_spec == (0, content_length-1)
+
+    def test_multiple_range_handling(self):
+        """Test that multipart ranges use first range only"""
+        helper = CDNHelper()
+
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="video/mp4",
+            content_length=10000,
+            range_header="bytes=0-999,1000-1999,2000-2999"
+        )
+
+        # Should process only first range
+        assert status == 206
+        assert range_spec == (0, 999)
+
+    def test_signed_url_creation_validation_cycle(self):
+        """Test creating and validating signed URL through helper"""
+        helper = CDNHelper(secret_key="test-secret")
+
+        url = helper.create_signed_asset_url(
+            "https://cdn.com/asset.gif",
+            expiration_seconds=7200
+        )
+
+        is_valid, error = helper.validate_asset_url(url)
+        assert is_valid is True
+        assert error is None
+
+    def test_cache_headers_combined_with_range(self):
+        """Test that cache headers are included with range responses"""
+        helper = CDNHelper()
+
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="video/mp4",
+            content_length=5000,
+            cache_duration=CachePolicy.LONG_CACHE,
+            range_header="bytes=0-1000"
+        )
+
+        # Should have both cache and range headers
+        assert "Cache-Control" in headers
+        assert "Content-Range" in headers
+        assert status == 206
+
+
+class TestIntegrationComplexScenarios:
+    """Complex integration scenarios"""
+
+    def test_signed_url_with_range_request(self):
+        """Test complete flow: signed URL + range request + caching"""
+        helper = CDNHelper(secret_key="integration-key")
+
+        # Step 1: Create signed URL
+        signed_url = helper.create_signed_asset_url(
+            "https://cdn.example.com/video.mp4",
+            expiration_seconds=3600
+        )
+
+        # Step 2: Validate it
+        is_valid, error = helper.validate_asset_url(signed_url)
+        assert is_valid is True
+
+        # Step 3: Get headers with range and immutable cache
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="video/mp4",
+            content_length=52428800,  # 50MB
+            is_immutable=True,
+            cache_duration=CachePolicy.IMMUTABLE_CACHE,
+            range_header="bytes=0-1048575"  # First MB
+        )
+
+        # Verify all components work together
+        assert status == 206
+        assert range_spec == (0, 1048575)
+        assert "immutable" in headers["Cache-Control"]
+        assert headers["Content-Range"] == "bytes 0-1048575/52428800"
+
+    def test_expired_signed_url_workflow(self):
+        """Test workflow with expired URL"""
+        helper = CDNHelper(secret_key="expire-test")
+
+        # Create URL that expires in 1 second
+        url = helper.create_signed_asset_url(
+            "https://cdn.com/asset.gif",
+            expiration_seconds=1
+        )
+
+        # Initially valid
+        is_valid, error = helper.validate_asset_url(url)
+        assert is_valid is True
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        # Now should be expired
+        is_valid, error = helper.validate_asset_url(url)
+        assert is_valid is False
+        assert "expired" in error.lower()
+
+    def test_no_cache_with_range_request(self):
+        """Test no-cache policy with range request"""
+        helper = CDNHelper()
+
+        headers, range_spec, status = helper.get_asset_headers(
+            content_type="application/json",
+            content_length=2048,
+            cache_duration=CachePolicy.NO_CACHE,
+            range_header="bytes=0-1023"
+        )
+
+        # Should have no-cache headers
+        assert "no-cache" in headers["Cache-Control"]
+        assert "no-store" in headers["Cache-Control"]
+        # And range headers
+        assert status == 206
+        assert headers["Content-Range"] == "bytes 0-1023/2048"
+
+
+class TestErrorConditions:
+    """Test error handling and edge cases"""
+
+    def test_range_request_empty_header(self):
+        """Test with empty range header string"""
+        result = RangeRequest.parse_range_header("", 1000)
+        assert result is None
+
+    def test_range_request_only_equals(self):
+        """Test range header with only equals sign"""
+        result = RangeRequest.parse_range_header("bytes=", 1000)
+        assert result is None
+
+    def test_range_request_only_dash(self):
+        """Test range header with only dash"""
+        result = RangeRequest.parse_range_header("bytes=-", 1000)
+        assert result is None
+
+    def test_signed_url_validation_empty_string(self):
+        """Test validating empty string"""
+        signer = SignedURL("secret")
+        is_valid, error = signer.validate_signed_url("")
+        assert is_valid is False
+
+    def test_content_type_special_characters(self):
+        """Test content type with special characters"""
+        helper = CDNHelper()
+        headers, _, status = helper.get_asset_headers(
+            content_type="application/vnd.custom+json; charset=utf-8",
+            content_length=1024
+        )
+
+        assert headers["Content-Type"] == "application/vnd.custom+json; charset=utf-8"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_edge_cases_advanced.py
+++ b/test_edge_cases_advanced.py
@@ -1,0 +1,627 @@
+"""
+Advanced Edge Cases and Stress Tests
+Additional comprehensive tests for error handling, limits, and edge cases
+"""
+import pytest
+import tempfile
+import os
+import sys
+from datetime import datetime, timedelta
+from analytics import AnalyticsTracker, EventType, Platform
+from sharelinks import ShareLinkGenerator, create_asset_hash
+
+
+class TestFileOperationErrors:
+    """Test error handling for file operations"""
+
+    def test_create_hash_directory_not_file(self):
+        """Test hashing a directory raises appropriate error"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises((IsADirectoryError, PermissionError, OSError)):
+                create_asset_hash(tmpdir)
+
+    def test_create_hash_invalid_path(self):
+        """Test hashing with invalid path characters"""
+        invalid_paths = [
+            "",  # Empty path
+            "\x00invalid",  # Null character (if OS allows)
+        ]
+        for path in invalid_paths:
+            try:
+                with pytest.raises((FileNotFoundError, OSError, ValueError)):
+                    create_asset_hash(path)
+            except:
+                # Some OSes may handle these differently
+                pass
+
+    def test_create_hash_special_files(self):
+        """Test hashing special system files (skip on Windows)"""
+        if sys.platform != 'win32':
+            # On Unix, try /dev/null
+            try:
+                hash_result = create_asset_hash('/dev/null')
+                # Should succeed and produce empty file hash
+                assert len(hash_result) == 64
+            except:
+                # May fail depending on system
+                pass
+
+    def test_create_hash_symlink(self):
+        """Test hashing a symbolic link"""
+        if sys.platform == 'win32':
+            pytest.skip("Symlink test not reliable on Windows")
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            f.write(b'target content')
+            target_path = f.name
+
+        link_path = target_path + '.link'
+        try:
+            os.symlink(target_path, link_path)
+            hash_target = create_asset_hash(target_path)
+            hash_link = create_asset_hash(link_path)
+            # Should produce same hash
+            assert hash_target == hash_link
+        except OSError:
+            pytest.skip("Symlinks not supported")
+        finally:
+            try:
+                os.unlink(link_path)
+            except:
+                pass
+            os.unlink(target_path)
+
+
+class TestAnalyticsInputValidation:
+    """Test analytics with invalid or edge case inputs"""
+
+    def test_track_event_empty_asset_id(self):
+        """Test tracking event with empty asset ID"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event("", EventType.VIEW)
+        assert event["asset_id"] == ""
+
+        metrics = tracker.get_asset_metrics("")
+        assert metrics["views"] == 1
+
+    def test_track_event_very_long_asset_id(self):
+        """Test with extremely long asset ID"""
+        tracker = AnalyticsTracker()
+        long_id = "a" * 10000
+        event = tracker.track_event(long_id, EventType.VIEW)
+        assert event["asset_id"] == long_id
+
+        metrics = tracker.get_asset_metrics(long_id)
+        assert metrics["views"] == 1
+
+    def test_track_event_special_characters_asset_id(self):
+        """Test asset IDs with special characters"""
+        tracker = AnalyticsTracker()
+        special_ids = [
+            "asset/with/slashes",
+            "asset\\with\\backslashes",
+            "asset?with=query&params",
+            "asset#with#hashes",
+            "asset\nwith\nnewlines",
+            "asset\twith\ttabs",
+            "asset with spaces",
+            "日本語アセット",  # Japanese
+            "🎉emoji🎊asset",  # Emoji
+        ]
+
+        for asset_id in special_ids:
+            event = tracker.track_event(asset_id, EventType.VIEW)
+            assert event["asset_id"] == asset_id
+            metrics = tracker.get_asset_metrics(asset_id)
+            assert metrics["views"] >= 1
+
+    def test_track_event_none_short_code(self):
+        """Test explicitly passing None as short_code"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event("asset1", EventType.VIEW, short_code=None)
+        assert event["short_code"] is None
+
+    def test_track_event_empty_metadata(self):
+        """Test with explicitly empty metadata"""
+        tracker = AnalyticsTracker()
+        event = tracker.track_event("asset1", EventType.VIEW, metadata={})
+        assert event["metadata"] == {}
+
+    def test_track_event_nested_metadata(self):
+        """Test with deeply nested metadata"""
+        tracker = AnalyticsTracker()
+        nested = {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "data": "deep"
+                    }
+                }
+            }
+        }
+        event = tracker.track_event("asset1", EventType.VIEW, metadata=nested)
+        assert event["metadata"]["level1"]["level2"]["level3"]["data"] == "deep"
+
+    def test_get_metrics_unicode_asset_ids(self):
+        """Test metrics with various unicode asset IDs"""
+        tracker = AnalyticsTracker()
+
+        # Track events with unicode IDs
+        tracker.track_event("アセット123", EventType.VIEW)
+        tracker.track_event("资产456", EventType.VIEW)
+        tracker.track_event("مُحتوى789", EventType.VIEW)
+
+        # Retrieve metrics
+        metrics1 = tracker.get_asset_metrics("アセット123")
+        metrics2 = tracker.get_asset_metrics("资产456")
+        metrics3 = tracker.get_asset_metrics("مُحتوى789")
+
+        assert metrics1["views"] == 1
+        assert metrics2["views"] == 1
+        assert metrics3["views"] == 1
+
+
+class TestAnalyticsStressAndLimits:
+    """Test analytics under stress and with large datasets"""
+
+    def test_track_many_events_single_asset(self):
+        """Test tracking thousands of events for single asset"""
+        tracker = AnalyticsTracker()
+
+        # Track 10,000 events
+        for i in range(10000):
+            if i % 3 == 0:
+                tracker.track_event("popular_asset", EventType.VIEW)
+            elif i % 3 == 1:
+                tracker.track_event("popular_asset", EventType.PLAY)
+            else:
+                tracker.track_event("popular_asset", EventType.CLICK)
+
+        metrics = tracker.get_asset_metrics("popular_asset")
+        assert metrics["views"] == 3334
+        assert metrics["plays"] == 3333
+        assert metrics["clicks"] == 3333
+        assert metrics["total_events"] == 10000
+
+    def test_track_many_unique_assets(self):
+        """Test tracking events across many unique assets"""
+        tracker = AnalyticsTracker()
+
+        # Create 1000 unique assets
+        for i in range(1000):
+            tracker.track_event(f"asset_{i}", EventType.VIEW)
+
+        # Get top assets
+        top = tracker.get_top_assets(metric="views", limit=100)
+        assert len(top) == 100
+
+    def test_very_large_metadata(self):
+        """Test with very large metadata objects"""
+        tracker = AnalyticsTracker()
+
+        # Create large metadata
+        large_meta = {
+            f"key_{i}": f"value_{i}" * 100 for i in range(100)
+        }
+
+        event = tracker.track_event("asset1", EventType.VIEW, metadata=large_meta)
+        assert len(event["metadata"]) == 100
+
+    def test_cache_behavior_under_load(self):
+        """Test cache invalidation with many rapid updates"""
+        tracker = AnalyticsTracker()
+
+        # Rapidly alternate between tracking and reading metrics
+        for i in range(100):
+            tracker.track_event("asset1", EventType.VIEW)
+            metrics = tracker.get_asset_metrics("asset1")
+            assert metrics["views"] == i + 1
+            # Cache should be invalidated each time
+
+    def test_platform_metrics_with_all_platforms_heavy_load(self):
+        """Test platform metrics with heavy load across all platforms"""
+        tracker = AnalyticsTracker()
+        platforms = [Platform.WEB, Platform.SLACK, Platform.DISCORD,
+                     Platform.TEAMS, Platform.TWITTER, Platform.FACEBOOK, Platform.OTHER]
+
+        # 1000 events per platform
+        for platform in platforms:
+            for _ in range(1000):
+                tracker.track_event("multi_platform_asset", EventType.VIEW, platform)
+
+        platform_metrics = tracker.get_platform_metrics("multi_platform_asset")
+        assert len(platform_metrics) == 7
+        for platform in platforms:
+            assert platform_metrics[platform.value]["views"] == 1000
+
+
+class TestShareLinksInputValidation:
+    """Test share links with invalid or edge case inputs"""
+
+    def test_generate_with_none_tags(self):
+        """Test that None tags are handled properly"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link("asset1", tags=None)
+        link_data = gen._links_db[result["short_code"]]
+        assert link_data["tags"] == []
+
+    def test_generate_with_none_title(self):
+        """Test creating link without title argument"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link("asset1")
+        link_data = gen._links_db[result["short_code"]]
+        assert link_data["title"] == ""
+
+    def test_tags_with_special_characters(self):
+        """Test tags containing special characters"""
+        gen = ShareLinkGenerator()
+        special_tags = [
+            "tag-with-dash",
+            "tag_with_underscore",
+            "tag.with.dots",
+            "tag with spaces",
+            "#hashtag",
+            "@mention",
+            "日本語タグ",
+            "emoji🎉tag"
+        ]
+
+        result = gen.create_share_link("asset1", tags=special_tags)
+        metadata = gen.get_share_metadata(result["short_code"])
+        assert len(metadata["tags"]) == len(special_tags)
+
+    def test_extremely_long_title(self):
+        """Test with title exceeding typical limits"""
+        gen = ShareLinkGenerator()
+        long_title = "A" * 100000  # 100k characters
+        result = gen.create_share_link("asset1", title=long_title)
+        metadata = gen.get_share_metadata(result["short_code"])
+        assert len(metadata["title"]) == 100000
+
+    def test_title_with_control_characters(self):
+        """Test title with control characters"""
+        gen = ShareLinkGenerator()
+        title_with_controls = "Title\x00with\x01control\x02chars"
+        result = gen.create_share_link("asset1", title=title_with_controls)
+        metadata = gen.get_share_metadata(result["short_code"])
+        assert metadata["title"] == title_with_controls
+
+    def test_base_url_with_query_params(self):
+        """Test base URL containing query parameters"""
+        gen = ShareLinkGenerator("https://example.com/app?ref=source")
+        url = gen.create_canonical_url("asset1")
+        assert url == "https://example.com/app?ref=source/a/asset1"
+
+    def test_base_url_with_fragment(self):
+        """Test base URL containing fragment"""
+        gen = ShareLinkGenerator("https://example.com#section")
+        url = gen.create_canonical_url("asset1")
+        assert url == "https://example.com#section/a/asset1"
+
+    def test_asset_id_only_special_chars(self):
+        """Test asset ID containing only special characters"""
+        gen = ShareLinkGenerator()
+        special_id = "!@#$%^&*()"
+        url = gen.create_canonical_url(special_id)
+        assert special_id in url
+
+
+class TestShareLinksStressAndLimits:
+    """Test share links under stress and with large datasets"""
+
+    def test_generate_many_links_collision_check(self):
+        """Test generating many links to verify no collisions"""
+        gen = ShareLinkGenerator()
+        codes = set()
+
+        # Generate 10,000 short codes
+        for i in range(10000):
+            result = gen.create_share_link(f"asset_{i}")
+            codes.add(result["short_code"])
+
+        # All should be unique
+        assert len(codes) == 10000
+
+    def test_resolve_many_links(self):
+        """Test resolving many links rapidly"""
+        gen = ShareLinkGenerator()
+
+        # Create 1000 links
+        links = []
+        for i in range(1000):
+            result = gen.create_share_link(f"asset_{i}")
+            links.append(result["short_code"])
+
+        # Resolve all
+        for i, code in enumerate(links):
+            resolved = gen.resolve_short_link(code)
+            assert resolved["asset_id"] == f"asset_{i}"
+
+    def test_link_database_size(self):
+        """Test that link database can handle many entries"""
+        gen = ShareLinkGenerator()
+
+        # Create 5000 links
+        for i in range(5000):
+            gen.create_share_link(f"asset_{i}", title=f"Title {i}", tags=[f"tag{i}"])
+
+        assert len(gen._links_db) == 5000
+
+    def test_heavy_click_tracking(self):
+        """Test click counter with many increments"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link("viral_asset")
+
+        # Simulate 10000 clicks
+        for _ in range(10000):
+            gen.resolve_short_link(result["short_code"])
+
+        assert gen._links_db[result["short_code"]]["clicks"] == 10000
+
+    def test_tags_list_with_duplicates(self):
+        """Test tags list containing duplicate entries"""
+        gen = ShareLinkGenerator()
+        tags_with_dupes = ["tag1", "tag2", "tag1", "tag3", "tag2"]
+        result = gen.create_share_link("asset1", tags=tags_with_dupes)
+
+        metadata = gen.get_share_metadata(result["short_code"])
+        # Duplicates are preserved (deduplication is application logic)
+        assert len(metadata["tags"]) == 5
+
+
+class TestTimeframeEdgeCases:
+    """Test timeframe queries with edge cases"""
+
+    def test_timeframe_with_future_dates(self):
+        """Test querying with dates far in the future"""
+        tracker = AnalyticsTracker()
+        tracker.track_event("asset1", EventType.VIEW)
+
+        future = datetime.utcnow() + timedelta(days=365 * 10)  # 10 years
+        events = tracker.get_events_by_timeframe("asset1", end_time=future)
+        assert len(events) == 1
+
+    def test_timeframe_with_past_dates(self):
+        """Test querying with dates far in the past"""
+        tracker = AnalyticsTracker()
+        tracker.track_event("asset1", EventType.VIEW)
+
+        past = datetime.utcnow() - timedelta(days=365 * 10)  # 10 years ago
+        events = tracker.get_events_by_timeframe("asset1", start_time=past)
+        assert len(events) == 1
+
+    def test_timeframe_inverted_range(self):
+        """Test with start_time after end_time"""
+        tracker = AnalyticsTracker()
+        tracker.track_event("asset1", EventType.VIEW)
+
+        now = datetime.utcnow()
+        past = now - timedelta(hours=1)
+        future = now + timedelta(hours=1)
+
+        # Inverted range should return no events
+        events = tracker.get_events_by_timeframe("asset1", start_time=future, end_time=past)
+        assert len(events) == 0
+
+    def test_timeframe_microsecond_precision(self):
+        """Test timeframe filtering with microsecond precision"""
+        tracker = AnalyticsTracker()
+
+        # Track events
+        event1 = tracker.track_event("asset1", EventType.VIEW)
+        event2 = tracker.track_event("asset1", EventType.PLAY)
+
+        time1 = datetime.fromisoformat(event1["timestamp"])
+        time2 = datetime.fromisoformat(event2["timestamp"])
+
+        # Query between the two events
+        events = tracker.get_events_by_timeframe("asset1", start_time=time1, end_time=time2)
+        assert len(events) >= 1
+
+
+class TestIntegrationStressScenarios:
+    """Stress test integration between modules"""
+
+    def test_many_assets_many_links_many_events(self):
+        """Test complete workflow with large numbers"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        # Create 100 assets, 3 links each, 10 events per link
+        for asset_num in range(100):
+            asset_id = f"asset_{asset_num}"
+
+            for link_num in range(3):
+                link = gen.create_share_link(asset_id, title=f"Link {link_num}")
+
+                for _ in range(10):
+                    tracker.track_event(asset_id, EventType.VIEW,
+                                      short_code=link["short_code"])
+
+        # Verify data integrity
+        asset_metrics = tracker.get_asset_metrics("asset_0")
+        assert asset_metrics["views"] == 30  # 3 links * 10 events
+
+    def test_concurrent_operations_simulation(self):
+        """Simulate concurrent operations on same asset"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        asset_id = "concurrent_asset"
+
+        # Simulate interleaved operations
+        link1 = gen.create_share_link(asset_id, title="Link 1")
+        tracker.track_event(asset_id, EventType.VIEW, short_code=link1["short_code"])
+
+        link2 = gen.create_share_link(asset_id, title="Link 2")
+        tracker.track_event(asset_id, EventType.VIEW, short_code=link1["short_code"])
+        tracker.track_event(asset_id, EventType.VIEW, short_code=link2["short_code"])
+
+        gen.resolve_short_link(link1["short_code"])
+        metrics1 = tracker.get_short_link_metrics(link1["short_code"])
+
+        gen.resolve_short_link(link2["short_code"])
+        metrics2 = tracker.get_short_link_metrics(link2["short_code"])
+
+        # Verify independence
+        assert metrics1["views"] == 2
+        assert metrics2["views"] == 1
+
+
+class TestMemoryAndResourceManagement:
+    """Test memory and resource efficiency"""
+
+    def test_clear_events_memory_reclaim(self):
+        """Test that clearing events allows memory reclamation"""
+        tracker = AnalyticsTracker()
+
+        # Create many events
+        for i in range(10000):
+            tracker.track_event(f"asset_{i}", EventType.VIEW)
+
+        initial_count = len(tracker._events)
+        assert initial_count == 10000
+
+        # Clear all
+        tracker.clear_events()
+        assert len(tracker._events) == 0
+        assert len(tracker._metrics_cache) == 0
+
+    def test_selective_event_clearing(self):
+        """Test memory management with selective clearing"""
+        tracker = AnalyticsTracker()
+
+        # Create events for multiple assets
+        for i in range(100):
+            for _ in range(100):
+                tracker.track_event(f"asset_{i}", EventType.VIEW)
+
+        # Clear just one asset
+        tracker.clear_events(asset_id="asset_0")
+
+        # Should have 99 * 100 = 9900 events left
+        assert len(tracker._events) == 9900
+
+    def test_link_database_cleanup_simulation(self):
+        """Test cleaning up old links from database"""
+        gen = ShareLinkGenerator()
+
+        # Create many links
+        codes_to_keep = []
+        codes_to_remove = []
+
+        for i in range(100):
+            result = gen.create_share_link(f"asset_{i}")
+            if i % 2 == 0:
+                codes_to_keep.append(result["short_code"])
+            else:
+                codes_to_remove.append(result["short_code"])
+
+        # Simulate cleanup by removing from database
+        for code in codes_to_remove:
+            if code in gen._links_db:
+                del gen._links_db[code]
+
+        # Verify selective removal
+        assert len(gen._links_db) == 50
+        for code in codes_to_keep:
+            assert gen.resolve_short_link(code) is not None
+        for code in codes_to_remove:
+            assert gen.resolve_short_link(code) is None
+
+
+class TestBoundaryMathematics:
+    """Test mathematical edge cases in calculations"""
+
+    def test_ctr_with_zero_views(self):
+        """Test CTR calculation when views is zero"""
+        tracker = AnalyticsTracker()
+        # Only clicks, no views (unusual but possible edge case)
+        tracker.track_event("asset1", EventType.CLICK)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["ctr"] == 0.0  # Should not divide by zero
+
+    def test_ctr_precision_edge_cases(self):
+        """Test CTR with numbers that cause precision issues"""
+        tracker = AnalyticsTracker()
+
+        # Create specific ratios
+        for _ in range(7):
+            tracker.track_event("asset1", EventType.VIEW)
+        for _ in range(3):
+            tracker.track_event("asset1", EventType.CLICK)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        # 3/7 * 100 = 42.857142...
+        assert metrics["ctr"] == 42.86
+
+    def test_play_rate_all_plays_no_views(self):
+        """Test play rate when only plays tracked"""
+        tracker = AnalyticsTracker()
+        tracker.track_event("asset1", EventType.PLAY)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        assert metrics["play_rate"] == 0.0
+
+    def test_very_high_ctr(self):
+        """Test CTR when clicks exceed views (edge case)"""
+        tracker = AnalyticsTracker()
+        tracker.track_event("asset1", EventType.VIEW)
+        # Somehow more clicks than views (data quality issue)
+        for _ in range(5):
+            tracker.track_event("asset1", EventType.CLICK)
+
+        metrics = tracker.get_asset_metrics("asset1")
+        # 5/1 * 100 = 500%
+        assert metrics["ctr"] == 500.0
+
+
+class TestAssetIDDeduplication:
+    """Test hash-based deduplication edge cases"""
+
+    def test_different_content_same_prefix(self):
+        """Test that files with same prefix produce different hashes"""
+        content1 = b"same_prefix_different_content_1"
+        content2 = b"same_prefix_different_content_2"
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f1:
+            f1.write(content1)
+            path1 = f1.name
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f2:
+            f2.write(content2)
+            path2 = f2.name
+
+        try:
+            hash1 = create_asset_hash(path1)
+            hash2 = create_asset_hash(path2)
+            assert hash1 != hash2
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_same_content_different_filenames(self):
+        """Test that same content in different files produces same hash"""
+        content = b"identical content"
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb', suffix='.gif') as f1:
+            f1.write(content)
+            path1 = f1.name
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb', suffix='.jpg') as f2:
+            f2.write(content)
+            path2 = f2.name
+
+        try:
+            hash1 = create_asset_hash(path1)
+            hash2 = create_asset_hash(path2)
+            # Content hashing should ignore filename/extension
+            assert hash1 == hash2
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,402 @@
+"""
+Integration Tests for Analytics + ShareLinks
+Tests the interaction between analytics and share link modules
+"""
+import pytest
+import tempfile
+import os
+from analytics import AnalyticsTracker, EventType, Platform
+from sharelinks import ShareLinkGenerator, create_asset_hash
+
+
+class TestAnalyticsShareLinksIntegration:
+    """Test integration between analytics tracking and share links"""
+
+    def test_track_share_link_usage(self):
+        """Test tracking analytics for share links"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        # Create a share link
+        link = gen.create_share_link("asset123", title="Test GIF")
+        short_code = link["short_code"]
+
+        # Track events with the short code
+        tracker.track_event("asset123", EventType.VIEW, Platform.SLACK, short_code=short_code)
+        tracker.track_event("asset123", EventType.PLAY, Platform.SLACK, short_code=short_code)
+        tracker.track_event("asset123", EventType.CLICK, Platform.SLACK, short_code=short_code)
+
+        # Verify analytics
+        metrics = tracker.get_short_link_metrics(short_code)
+        assert metrics["views"] == 1
+        assert metrics["plays"] == 1
+        assert metrics["clicks"] == 1
+        assert metrics["ctr"] == 100.0
+
+        # Verify share link resolution
+        resolved = gen.resolve_short_link(short_code)
+        assert resolved["asset_id"] == "asset123"
+        assert resolved["clicks"] == 1  # From share link tracking
+
+    def test_multiple_share_links_analytics(self):
+        """Test analytics for multiple share links of same asset"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        # Create multiple share links for same asset
+        link1 = gen.create_share_link("asset999", title="Link 1")
+        link2 = gen.create_share_link("asset999", title="Link 2")
+
+        # Track events for different links
+        tracker.track_event("asset999", EventType.VIEW, Platform.SLACK, short_code=link1["short_code"])
+        tracker.track_event("asset999", EventType.VIEW, Platform.DISCORD, short_code=link2["short_code"])
+        tracker.track_event("asset999", EventType.CLICK, Platform.SLACK, short_code=link1["short_code"])
+
+        # Check overall asset metrics
+        asset_metrics = tracker.get_asset_metrics("asset999")
+        assert asset_metrics["views"] == 2
+        assert asset_metrics["clicks"] == 1
+
+        # Check individual link metrics
+        link1_metrics = tracker.get_short_link_metrics(link1["short_code"])
+        link2_metrics = tracker.get_short_link_metrics(link2["short_code"])
+
+        assert link1_metrics["views"] == 1
+        assert link1_metrics["clicks"] == 1
+        assert link2_metrics["views"] == 1
+        assert link2_metrics["clicks"] == 0
+
+    def test_platform_tracking_with_share_links(self):
+        """Test platform-specific analytics with share links"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        link = gen.create_share_link("asset777")
+        short_code = link["short_code"]
+
+        # Track events from different platforms
+        for _ in range(5):
+            tracker.track_event("asset777", EventType.VIEW, Platform.SLACK, short_code=short_code)
+        for _ in range(3):
+            tracker.track_event("asset777", EventType.VIEW, Platform.DISCORD, short_code=short_code)
+        tracker.track_event("asset777", EventType.CLICK, Platform.SLACK, short_code=short_code)
+
+        # Check platform breakdown
+        platform_metrics = tracker.get_platform_metrics("asset777")
+        assert platform_metrics["slack"]["views"] == 5
+        assert platform_metrics["slack"]["clicks"] == 1
+        assert platform_metrics["discord"]["views"] == 3
+
+    def test_canonical_url_analytics_tracking(self):
+        """Test tracking analytics for canonical URLs (no short code)"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        canonical_url = gen.create_canonical_url("asset555")
+
+        # Track events without short code (direct canonical URL access)
+        tracker.track_event("asset555", EventType.VIEW, Platform.WEB)
+        tracker.track_event("asset555", EventType.VIEW, Platform.WEB)
+
+        metrics = tracker.get_asset_metrics("asset555")
+        assert metrics["views"] == 2
+
+
+class TestHashBasedWorkflow:
+    """Test complete workflow using hash-based asset IDs"""
+
+    def test_hash_to_analytics_workflow(self):
+        """Test workflow from file hash to analytics tracking"""
+        # Create test file
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            f.write(b"GIF content here")
+            temp_path = f.name
+
+        try:
+            # Step 1: Hash the file
+            content_hash = create_asset_hash(temp_path)
+
+            # Step 2: Generate deterministic asset ID
+            gen = ShareLinkGenerator()
+            asset_id = gen.generate_hash_based_id(content_hash)
+
+            # Step 3: Create share link
+            link = gen.create_share_link(asset_id, title="Hashed GIF")
+
+            # Step 4: Track analytics
+            tracker = AnalyticsTracker()
+            tracker.track_event(asset_id, EventType.VIEW, short_code=link["short_code"])
+            tracker.track_event(asset_id, EventType.PLAY, short_code=link["short_code"])
+
+            # Verify everything is connected
+            link_metrics = tracker.get_short_link_metrics(link["short_code"])
+            assert link_metrics["asset_id"] == asset_id
+            assert link_metrics["views"] == 1
+            assert link_metrics["plays"] == 1
+
+            resolved = gen.resolve_short_link(link["short_code"])
+            assert resolved["asset_id"] == asset_id
+            assert resolved["canonical_url"] == gen.create_canonical_url(asset_id)
+        finally:
+            os.unlink(temp_path)
+
+    def test_deduplication_with_analytics(self):
+        """Test that duplicate content uses same asset ID in analytics"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+        content = b"Duplicate test content"
+
+        # Upload "same" content twice
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f1:
+            f1.write(content)
+            path1 = f1.name
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f2:
+            f2.write(content)
+            path2 = f2.name
+
+        try:
+            # Both files should produce same asset ID
+            hash1 = create_asset_hash(path1)
+            hash2 = create_asset_hash(path2)
+            asset_id1 = gen.generate_hash_based_id(hash1)
+            asset_id2 = gen.generate_hash_based_id(hash2)
+
+            assert asset_id1 == asset_id2
+
+            # Track events for "different uploads" of same content
+            tracker.track_event(asset_id1, EventType.VIEW)
+            tracker.track_event(asset_id2, EventType.VIEW)
+
+            # Should aggregate to same asset
+            metrics = tracker.get_asset_metrics(asset_id1)
+            assert metrics["views"] == 2
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+
+class TestCrossModuleMetadata:
+    """Test metadata consistency across modules"""
+
+    def test_metadata_consistency(self):
+        """Test that metadata is consistent between modules"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        # Create share link with metadata
+        link = gen.create_share_link(
+            "asset444",
+            title="Epic GIF",
+            tags=["funny", "viral"]
+        )
+
+        # Get share link metadata
+        share_metadata = gen.get_share_metadata(link["short_code"])
+
+        # Track event with metadata
+        event_metadata = {
+            "referrer": "https://example.com",
+            "user_agent": "Mozilla/5.0"
+        }
+        tracker.track_event(
+            "asset444",
+            EventType.VIEW,
+            short_code=link["short_code"],
+            metadata=event_metadata
+        )
+
+        # Verify both maintain their own metadata
+        assert share_metadata["title"] == "Epic GIF"
+        assert share_metadata["tags"] == ["funny", "viral"]
+
+        events = tracker.get_events_by_timeframe("asset444")
+        assert events[0]["metadata"]["referrer"] == "https://example.com"
+
+    def test_share_link_with_custom_base_url(self):
+        """Test analytics work with custom base URLs"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator("https://custom-domain.com")
+
+        link = gen.create_share_link("asset888")
+
+        # Verify custom URLs
+        assert "custom-domain.com" in link["short_url"]
+        assert "custom-domain.com" in link["canonical_url"]
+
+        # Track analytics
+        tracker.track_event("asset888", EventType.VIEW, short_code=link["short_code"])
+
+        metrics = tracker.get_short_link_metrics(link["short_code"])
+        assert metrics["asset_id"] == "asset888"
+
+
+class TestRealWorldScenarios:
+    """Test realistic usage scenarios"""
+
+    def test_viral_content_scenario(self):
+        """Test scenario where content goes viral across platforms"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        # Create share links for different platforms
+        slack_link = gen.create_share_link("viral_gif", title="Viral on Slack")
+        discord_link = gen.create_share_link("viral_gif", title="Viral on Discord")
+
+        # Simulate viral spread on Slack
+        for _ in range(100):
+            tracker.track_event("viral_gif", EventType.VIEW, Platform.SLACK,
+                              short_code=slack_link["short_code"])
+        for _ in range(80):
+            tracker.track_event("viral_gif", EventType.PLAY, Platform.SLACK,
+                              short_code=slack_link["short_code"])
+        for _ in range(20):
+            tracker.track_event("viral_gif", EventType.CLICK, Platform.SLACK,
+                              short_code=slack_link["short_code"])
+
+        # Simulate spread on Discord
+        for _ in range(50):
+            tracker.track_event("viral_gif", EventType.VIEW, Platform.DISCORD,
+                              short_code=discord_link["short_code"])
+        for _ in range(30):
+            tracker.track_event("viral_gif", EventType.PLAY, Platform.DISCORD,
+                              short_code=discord_link["short_code"])
+
+        # Check overall metrics
+        asset_metrics = tracker.get_asset_metrics("viral_gif")
+        assert asset_metrics["views"] == 150
+        assert asset_metrics["plays"] == 110
+        assert asset_metrics["clicks"] == 20
+
+        # Check platform breakdown
+        platform_metrics = tracker.get_platform_metrics("viral_gif")
+        assert platform_metrics["slack"]["views"] == 100
+        assert platform_metrics["discord"]["views"] == 50
+
+        # Check individual link performance
+        slack_metrics = tracker.get_short_link_metrics(slack_link["short_code"])
+        discord_metrics = tracker.get_short_link_metrics(discord_link["short_code"])
+
+        assert slack_metrics["ctr"] == 20.0
+        assert discord_metrics["ctr"] == 0.0
+
+    def test_ab_testing_scenario(self):
+        """Test A/B testing different share link titles"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        # Create two variants
+        variant_a = gen.create_share_link("asset_ab", title="Click me!")
+        variant_b = gen.create_share_link("asset_ab", title="Amazing GIF Inside")
+
+        # Simulate traffic
+        for _ in range(100):
+            tracker.track_event("asset_ab", EventType.VIEW, short_code=variant_a["short_code"])
+        for _ in range(10):
+            tracker.track_event("asset_ab", EventType.CLICK, short_code=variant_a["short_code"])
+
+        for _ in range(100):
+            tracker.track_event("asset_ab", EventType.VIEW, short_code=variant_b["short_code"])
+        for _ in range(25):
+            tracker.track_event("asset_ab", EventType.CLICK, short_code=variant_b["short_code"])
+
+        # Compare performance
+        a_metrics = tracker.get_short_link_metrics(variant_a["short_code"])
+        b_metrics = tracker.get_short_link_metrics(variant_b["short_code"])
+
+        assert a_metrics["ctr"] == 10.0
+        assert b_metrics["ctr"] == 25.0  # Variant B performs better
+
+    def test_campaign_tracking(self):
+        """Test tracking a marketing campaign across platforms"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        campaign_asset = "campaign_2025"
+
+        # Create platform-specific links
+        twitter_link = gen.create_share_link(campaign_asset, tags=["campaign", "twitter"])
+        facebook_link = gen.create_share_link(campaign_asset, tags=["campaign", "facebook"])
+        email_link = gen.create_share_link(campaign_asset, tags=["campaign", "email"])
+
+        # Track campaign performance
+        tracker.track_event(campaign_asset, EventType.VIEW, Platform.TWITTER,
+                          short_code=twitter_link["short_code"])
+        tracker.track_event(campaign_asset, EventType.CLICK, Platform.TWITTER,
+                          short_code=twitter_link["short_code"])
+
+        tracker.track_event(campaign_asset, EventType.VIEW, Platform.FACEBOOK,
+                          short_code=facebook_link["short_code"])
+
+        tracker.track_event(campaign_asset, EventType.VIEW, Platform.WEB,
+                          short_code=email_link["short_code"])
+        tracker.track_event(campaign_asset, EventType.PLAY, Platform.WEB,
+                          short_code=email_link["short_code"])
+
+        # Analyze campaign
+        campaign_metrics = tracker.get_asset_metrics(campaign_asset)
+        assert campaign_metrics["views"] == 3
+        assert campaign_metrics["plays"] == 1
+        assert campaign_metrics["clicks"] == 1
+
+        # Check which channel performed best
+        twitter_metrics = tracker.get_short_link_metrics(twitter_link["short_code"])
+        assert twitter_metrics["ctr"] == 100.0  # Best performing
+
+
+class TestErrorHandlingIntegration:
+    """Test error handling across both modules"""
+
+    def test_analytics_for_nonexistent_link(self):
+        """Test tracking analytics for a short code that doesn't exist in share links"""
+        tracker = AnalyticsTracker()
+
+        # Track with non-existent short code (analytics should still work)
+        tracker.track_event("asset123", EventType.VIEW, short_code="nonexistent")
+
+        metrics = tracker.get_short_link_metrics("nonexistent")
+        assert metrics["views"] == 1
+
+    def test_resolve_link_without_analytics(self):
+        """Test resolving share link that has no analytics data"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        link = gen.create_share_link("unused_asset")
+
+        # Resolve without any analytics
+        resolved = gen.resolve_short_link(link["short_code"])
+        assert resolved["asset_id"] == "unused_asset"
+
+        # Analytics should show zero
+        metrics = tracker.get_short_link_metrics(link["short_code"])
+        assert metrics["views"] == 0
+
+    def test_mixed_tracking_with_and_without_short_codes(self):
+        """Test mixing direct and share link traffic"""
+        tracker = AnalyticsTracker()
+        gen = ShareLinkGenerator()
+
+        link = gen.create_share_link("mixed_asset")
+
+        # Some events with short code
+        tracker.track_event("mixed_asset", EventType.VIEW, short_code=link["short_code"])
+        tracker.track_event("mixed_asset", EventType.PLAY, short_code=link["short_code"])
+
+        # Some events without (direct canonical URL access)
+        tracker.track_event("mixed_asset", EventType.VIEW)
+        tracker.track_event("mixed_asset", EventType.PLAY)
+
+        # Overall metrics should include both
+        asset_metrics = tracker.get_asset_metrics("mixed_asset")
+        assert asset_metrics["views"] == 2
+        assert asset_metrics["plays"] == 2
+
+        # Short link metrics only count events with short code
+        link_metrics = tracker.get_short_link_metrics(link["short_code"])
+        assert link_metrics["views"] == 1
+        assert link_metrics["plays"] == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_integration_cross_module.py
+++ b/test_integration_cross_module.py
@@ -1,0 +1,521 @@
+"""
+Cross-module integration tests
+Tests interactions between Analytics, ShareLinks, and CDN modules
+"""
+import pytest
+import tempfile
+import os
+from datetime import datetime, timedelta
+
+from analytics import AnalyticsTracker, EventType, Platform
+from sharelinks import ShareLinkGenerator, create_asset_hash
+from cdn import CDNHelper, CachePolicy, SignedURL
+
+
+class TestAnalyticsWithShareLinks:
+    """Test analytics tracking with share links"""
+
+    def test_track_share_link_clicks_and_views(self):
+        """Test complete workflow: create link, track views and clicks"""
+        gen = ShareLinkGenerator()
+        tracker = AnalyticsTracker()
+
+        # Create share link
+        link = gen.create_share_link("asset123", title="Test Asset")
+
+        # Track various events through the link
+        tracker.track_event("asset123", EventType.VIEW,
+                          Platform.SLACK, short_code=link["short_code"])
+        tracker.track_event("asset123", EventType.PLAY,
+                          Platform.SLACK, short_code=link["short_code"])
+        tracker.track_event("asset123", EventType.CLICK,
+                          Platform.SLACK, short_code=link["short_code"])
+
+        # Verify analytics
+        metrics = tracker.get_short_link_metrics(link["short_code"])
+        assert metrics["views"] == 1
+        assert metrics["plays"] == 1
+        assert metrics["clicks"] == 1
+        assert metrics["ctr"] == 100.0
+
+        # Verify share link tracking
+        resolved = gen.resolve_short_link(link["short_code"])
+        assert resolved["clicks"] == 1
+
+    def test_multiple_links_same_asset_analytics(self):
+        """Test analytics across multiple share links for same asset"""
+        gen = ShareLinkGenerator()
+        tracker = AnalyticsTracker()
+
+        asset_id = "popular_asset"
+
+        # Create 3 different share links
+        link1 = gen.create_share_link(asset_id, title="Link 1")
+        link2 = gen.create_share_link(asset_id, title="Link 2")
+        link3 = gen.create_share_link(asset_id, title="Link 3")
+
+        # Track events through different links
+        # Link 1: 10 views, 5 clicks
+        for _ in range(10):
+            tracker.track_event(asset_id, EventType.VIEW,
+                              short_code=link1["short_code"])
+        for _ in range(5):
+            tracker.track_event(asset_id, EventType.CLICK,
+                              short_code=link1["short_code"])
+
+        # Link 2: 20 views, 10 clicks
+        for _ in range(20):
+            tracker.track_event(asset_id, EventType.VIEW,
+                              short_code=link2["short_code"])
+        for _ in range(10):
+            tracker.track_event(asset_id, EventType.CLICK,
+                              short_code=link2["short_code"])
+
+        # Link 3: 5 views, 1 click
+        for _ in range(5):
+            tracker.track_event(asset_id, EventType.VIEW,
+                              short_code=link3["short_code"])
+        tracker.track_event(asset_id, EventType.CLICK,
+                          short_code=link3["short_code"])
+
+        # Verify individual link metrics
+        metrics1 = tracker.get_short_link_metrics(link1["short_code"])
+        metrics2 = tracker.get_short_link_metrics(link2["short_code"])
+        metrics3 = tracker.get_short_link_metrics(link3["short_code"])
+
+        assert metrics1["ctr"] == 50.0
+        assert metrics2["ctr"] == 50.0
+        assert metrics3["ctr"] == 20.0
+
+        # Verify aggregate asset metrics
+        asset_metrics = tracker.get_asset_metrics(asset_id)
+        assert asset_metrics["views"] == 35
+        assert asset_metrics["clicks"] == 16
+
+    def test_platform_breakdown_with_share_links(self):
+        """Test platform analytics with share links"""
+        gen = ShareLinkGenerator()
+        tracker = AnalyticsTracker()
+
+        asset_id = "multi_platform_asset"
+        link = gen.create_share_link(asset_id)
+
+        # Share on different platforms
+        tracker.track_event(asset_id, EventType.VIEW, Platform.SLACK,
+                          short_code=link["short_code"])
+        tracker.track_event(asset_id, EventType.VIEW, Platform.DISCORD,
+                          short_code=link["short_code"])
+        tracker.track_event(asset_id, EventType.VIEW, Platform.TWITTER,
+                          short_code=link["short_code"])
+        tracker.track_event(asset_id, EventType.CLICK, Platform.SLACK,
+                          short_code=link["short_code"])
+
+        # Check platform breakdown
+        platform_metrics = tracker.get_platform_metrics(asset_id)
+        assert len(platform_metrics) == 3
+        assert platform_metrics["slack"]["views"] == 1
+        assert platform_metrics["slack"]["clicks"] == 1
+
+
+class TestCDNWithShareLinks:
+    """Test CDN functionality with share links"""
+
+    def test_signed_url_for_share_link(self):
+        """Test creating signed URLs for assets with share links"""
+        gen = ShareLinkGenerator()
+        cdn = CDNHelper(secret_key="test-secret")
+
+        # Create share link
+        link = gen.create_share_link("asset_cdn_123")
+
+        # Create signed CDN URL for the canonical URL
+        signed_url = cdn.create_signed_asset_url(link["canonical_url"])
+
+        # Validate it
+        is_valid, error = cdn.validate_asset_url(signed_url)
+        assert is_valid is True
+        assert error is None
+
+    def test_cdn_headers_for_shared_asset(self):
+        """Test getting CDN headers for a shared asset"""
+        gen = ShareLinkGenerator()
+        cdn = CDNHelper()
+
+        # Create share link for a GIF
+        link = gen.create_share_link("gif_asset_456")
+
+        # Get CDN headers for serving this asset
+        headers, range_spec, status = cdn.get_asset_headers(
+            content_type="image/gif",
+            content_length=2048576,  # ~2MB
+            is_immutable=False,
+            cache_duration=CachePolicy.LONG_CACHE
+        )
+
+        assert status == 200
+        assert "Cache-Control" in headers
+        assert headers["Content-Type"] == "image/gif"
+
+    def test_range_request_with_share_link_analytics(self):
+        """Test range requests tracked in analytics"""
+        gen = ShareLinkGenerator()
+        cdn = CDNHelper()
+        tracker = AnalyticsTracker()
+
+        asset_id = "video_asset"
+        link = gen.create_share_link(asset_id, title="Video Asset")
+
+        # Simulate progressive video loading with range requests
+        content_length = 10485760  # 10MB
+        chunk_size = 1048576  # 1MB
+
+        for i in range(3):
+            start = i * chunk_size
+            end = start + chunk_size - 1
+
+            # Get CDN headers for range
+            headers, range_spec, status = cdn.get_asset_headers(
+                content_type="video/mp4",
+                content_length=content_length,
+                range_header=f"bytes={start}-{end}"
+            )
+
+            assert status == 206
+
+            # Track as a view or play event
+            if i == 0:
+                tracker.track_event(asset_id, EventType.VIEW,
+                                  short_code=link["short_code"])
+            tracker.track_event(asset_id, EventType.PLAY,
+                              short_code=link["short_code"])
+
+        # Verify analytics
+        metrics = tracker.get_short_link_metrics(link["short_code"])
+        assert metrics["views"] == 1
+        assert metrics["plays"] == 3
+
+
+class TestFullWorkflowIntegration:
+    """Test complete end-to-end workflows"""
+
+    def test_complete_asset_lifecycle(self):
+        """Test complete lifecycle: upload -> hash -> link -> CDN -> analytics"""
+        # Step 1: Create and hash asset file
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            f.write(b"GIF89a" + b"\x00" * 1000)  # Mock GIF data
+            temp_path = f.name
+
+        try:
+            # Step 2: Hash the file
+            content_hash = create_asset_hash(temp_path)
+            assert len(content_hash) == 64
+
+            # Step 3: Generate asset ID from hash
+            gen = ShareLinkGenerator()
+            asset_id = gen.generate_hash_based_id(content_hash)
+            assert len(asset_id) == 16
+
+            # Step 4: Create share link
+            link = gen.create_share_link(asset_id, title="My GIF", tags=["test"])
+            assert link["canonical_url"] == f"https://gifdist.io/a/{asset_id}"
+
+            # Step 5: Create signed CDN URL
+            cdn = CDNHelper(secret_key="production-secret")
+            signed_url = cdn.create_signed_asset_url(
+                link["canonical_url"],
+                expiration_seconds=3600
+            )
+
+            # Step 6: Validate signed URL
+            is_valid, error = cdn.validate_asset_url(signed_url)
+            assert is_valid is True
+
+            # Step 7: Get CDN headers for delivery
+            headers, _, status = cdn.get_asset_headers(
+                content_type="image/gif",
+                content_length=1006,
+                is_immutable=True,
+                cache_duration=CachePolicy.IMMUTABLE_CACHE
+            )
+            assert "immutable" in headers["Cache-Control"]
+
+            # Step 8: Track analytics events
+            tracker = AnalyticsTracker()
+            tracker.track_event(asset_id, EventType.VIEW, Platform.SLACK,
+                              short_code=link["short_code"])
+            tracker.track_event(asset_id, EventType.PLAY, Platform.SLACK,
+                              short_code=link["short_code"])
+            tracker.track_event(asset_id, EventType.CLICK, Platform.SLACK,
+                              short_code=link["short_code"])
+
+            # Step 9: Verify complete analytics
+            metrics = tracker.get_asset_metrics(asset_id)
+            assert metrics["views"] == 1
+            assert metrics["plays"] == 1
+            assert metrics["clicks"] == 1
+            assert metrics["ctr"] == 100.0
+
+            link_metrics = tracker.get_short_link_metrics(link["short_code"])
+            assert link_metrics["asset_id"] == asset_id
+
+            # Step 10: Verify share link resolution
+            resolved = gen.resolve_short_link(link["short_code"])
+            assert resolved["asset_id"] == asset_id
+            assert resolved["title"] == "My GIF"
+
+        finally:
+            os.unlink(temp_path)
+
+    def test_viral_content_scenario(self):
+        """Test scenario of viral content shared across platforms"""
+        # Setup
+        gen = ShareLinkGenerator()
+        tracker = AnalyticsTracker()
+        cdn = CDNHelper(secret_key="viral-key")
+
+        # Upload viral GIF
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            f.write(b"GIF89a" + b"\xFF" * 5000)
+            temp_path = f.name
+
+        try:
+            content_hash = create_asset_hash(temp_path)
+            asset_id = gen.generate_hash_based_id(content_hash)
+
+            # Create multiple share links for different platforms
+            slack_link = gen.create_share_link(asset_id, title="Check this out!")
+            twitter_link = gen.create_share_link(asset_id, title="Going viral!")
+            discord_link = gen.create_share_link(asset_id, title="Epic GIF")
+
+            # Create signed CDN URLs
+            slack_cdn = cdn.create_signed_asset_url(slack_link["canonical_url"])
+            twitter_cdn = cdn.create_signed_asset_url(twitter_link["canonical_url"])
+            discord_cdn = cdn.create_signed_asset_url(discord_link["canonical_url"])
+
+            # Simulate viral spread
+            platforms_events = [
+                (Platform.SLACK, slack_link["short_code"], 1000),
+                (Platform.TWITTER, twitter_link["short_code"], 5000),
+                (Platform.DISCORD, discord_link["short_code"], 2000),
+            ]
+
+            for platform, short_code, view_count in platforms_events:
+                for _ in range(view_count):
+                    tracker.track_event(asset_id, EventType.VIEW, platform,
+                                      short_code=short_code)
+                # 10% click through rate
+                for _ in range(view_count // 10):
+                    tracker.track_event(asset_id, EventType.CLICK, platform,
+                                      short_code=short_code)
+
+            # Analyze viral performance
+            asset_metrics = tracker.get_asset_metrics(asset_id)
+            assert asset_metrics["views"] == 8000
+            assert asset_metrics["clicks"] == 800
+            assert asset_metrics["ctr"] == 10.0
+
+            platform_metrics = tracker.get_platform_metrics(asset_id)
+            assert platform_metrics["twitter"]["views"] == 5000
+            assert platform_metrics["slack"]["views"] == 1000
+            assert platform_metrics["discord"]["views"] == 2000
+
+            # Get top performing link
+            twitter_metrics = tracker.get_short_link_metrics(twitter_link["short_code"])
+            assert twitter_metrics["views"] == 5000
+
+        finally:
+            os.unlink(temp_path)
+
+    def test_content_deduplication_workflow(self):
+        """Test deduplication of identical content"""
+        gen = ShareLinkGenerator()
+
+        # Create two identical files
+        content = b"GIF89a" + b"\xAB" * 2000
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f1:
+            f1.write(content)
+            path1 = f1.name
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f2:
+            f2.write(content)
+            path2 = f2.name
+
+        try:
+            # Hash both files
+            hash1 = create_asset_hash(path1)
+            hash2 = create_asset_hash(path2)
+
+            # Hashes should be identical
+            assert hash1 == hash2
+
+            # Generate asset IDs
+            id1 = gen.generate_hash_based_id(hash1)
+            id2 = gen.generate_hash_based_id(hash2)
+
+            # IDs should be identical (deduplication)
+            assert id1 == id2
+
+            # Creating share links will use same asset ID
+            link1 = gen.create_share_link(id1, title="First upload")
+            link2 = gen.create_share_link(id2, title="Duplicate upload")
+
+            # Different short codes
+            assert link1["short_code"] != link2["short_code"]
+
+            # But same canonical URL (same asset)
+            assert link1["canonical_url"] == link2["canonical_url"]
+
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+
+class TestConcurrentAccessPatterns:
+    """Test patterns simulating concurrent access"""
+
+    def test_simultaneous_analytics_and_link_resolution(self):
+        """Test tracking analytics while resolving links"""
+        gen = ShareLinkGenerator()
+        tracker = AnalyticsTracker()
+
+        asset_id = "concurrent_asset"
+        link = gen.create_share_link(asset_id)
+
+        # Simulate interleaved operations
+        for i in range(100):
+            # Track event
+            tracker.track_event(asset_id, EventType.VIEW,
+                              short_code=link["short_code"])
+
+            # Resolve link (increments click counter)
+            resolved = gen.resolve_short_link(link["short_code"])
+            assert resolved is not None
+
+            # Get metrics
+            metrics = tracker.get_short_link_metrics(link["short_code"])
+            assert metrics["views"] == i + 1
+
+        # Final verification
+        assert gen._links_db[link["short_code"]]["clicks"] == 100
+        final_metrics = tracker.get_asset_metrics(asset_id)
+        assert final_metrics["views"] == 100
+
+    def test_multiple_cdn_requests_same_asset(self):
+        """Test multiple simultaneous CDN requests for same asset"""
+        cdn = CDNHelper()
+        gen = ShareLinkGenerator()
+
+        asset_id = "popular_video"
+        link = gen.create_share_link(asset_id)
+        content_length = 20971520  # 20MB
+
+        # Simulate multiple clients requesting different ranges
+        ranges = [
+            "bytes=0-1048575",      # Client 1: first MB
+            "bytes=1048576-2097151", # Client 2: second MB
+            "bytes=0-1048575",       # Client 3: first MB again
+            "bytes=10485760-11534335", # Client 4: chunk from middle
+        ]
+
+        results = []
+        for range_header in ranges:
+            headers, range_spec, status = cdn.get_asset_headers(
+                content_type="video/mp4",
+                content_length=content_length,
+                range_header=range_header,
+                cache_duration=CachePolicy.LONG_CACHE
+            )
+            results.append((status, range_spec))
+
+        # All should succeed
+        assert all(status == 206 for status, _ in results)
+        assert results[0][1] == results[2][1]  # Same range for clients 1 and 3
+
+
+class TestErrorHandlingAcrossModules:
+    """Test error handling in cross-module scenarios"""
+
+    def test_analytics_with_nonexistent_short_code(self):
+        """Test analytics for short code that doesn't exist"""
+        tracker = AnalyticsTracker()
+
+        # Track event with non-existent short code (analytics doesn't validate codes)
+        event = tracker.track_event("asset1", EventType.VIEW,
+                                   short_code="nonexistent")
+        assert event["short_code"] == "nonexistent"
+
+        # Get metrics for the short code we just created
+        metrics = tracker.get_short_link_metrics("nonexistent")
+        # Analytics tracks events regardless of whether the link exists in ShareLinkGenerator
+        assert metrics["views"] == 1
+        assert metrics["asset_id"] == "asset1"
+
+    def test_cdn_signed_url_with_invalid_share_link_url(self):
+        """Test CDN signing with malformed share link URL"""
+        cdn = CDNHelper(secret_key="test")
+
+        # Try to sign a malformed URL
+        url = cdn.create_signed_asset_url("not-a-valid-url")
+        # Should still create a signed URL (validation is CDN's job)
+        assert "signature=" in url
+
+    def test_hash_collision_handling(self):
+        """Test handling of hash prefix collisions (very rare)"""
+        gen = ShareLinkGenerator()
+
+        # Generate IDs from similar hashes
+        hash1 = "abcdef1234567890" + "0" * 48
+        hash2 = "abcdef1234567890" + "1" * 48
+
+        id1 = gen.generate_hash_based_id(hash1)
+        id2 = gen.generate_hash_based_id(hash2)
+
+        # First 16 chars are same, so IDs collide
+        assert id1 == id2
+
+        # Creating links should still work (different short codes)
+        link1 = gen.create_share_link(id1, title="First")
+        link2 = gen.create_share_link(id2, title="Second")
+
+        assert link1["short_code"] != link2["short_code"]
+        assert link1["canonical_url"] == link2["canonical_url"]
+
+
+class TestPerformanceIntegration:
+    """Test performance characteristics of integrated workflows"""
+
+    def test_bulk_asset_processing(self):
+        """Test processing many assets through complete pipeline"""
+        gen = ShareLinkGenerator()
+        tracker = AnalyticsTracker()
+        cdn = CDNHelper(secret_key="bulk-test")
+
+        # Process 100 assets
+        for i in range(100):
+            asset_id = f"asset_{i}"
+
+            # Create share link
+            link = gen.create_share_link(asset_id, title=f"Asset {i}")
+
+            # Create signed URL
+            signed = cdn.create_signed_asset_url(link["canonical_url"])
+
+            # Track some events
+            tracker.track_event(asset_id, EventType.VIEW,
+                              short_code=link["short_code"])
+
+            if i % 10 == 0:
+                tracker.track_event(asset_id, EventType.CLICK,
+                                  short_code=link["short_code"])
+
+        # Verify all processed
+        assert len(gen._links_db) == 100
+        assert len(tracker._events) == 110  # 100 views + 10 clicks
+
+        top_assets = tracker.get_top_assets(metric="clicks", limit=10)
+        assert len(top_assets) == 10
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_moderation.py
+++ b/test_moderation.py
@@ -1,0 +1,535 @@
+"""
+Tests for SFW-only Moderation Pipeline & Audit
+"""
+import pytest
+import time
+from moderation import (
+    ModerationPipeline,
+    ContentScanner,
+    ModerationDecision,
+    ContentCategory,
+    ModerationResult,
+    AuditEntry,
+    ModerationError
+)
+
+
+class TestContentScanner:
+    """Test content scanner functionality"""
+
+    def test_scanner_init(self):
+        """Test scanner initialization"""
+        scanner = ContentScanner(strict_mode=True)
+        assert scanner.strict_mode is True
+        assert len(scanner.nsfw_keywords) > 0
+
+    def test_safe_metadata(self):
+        """Test scanning safe metadata"""
+        scanner = ContentScanner()
+        category, confidence, reasons = scanner.scan_metadata(
+            title="Cute Cat GIF",
+            tags=["cat", "funny", "cute"],
+            description="A funny cat playing with yarn"
+        )
+        assert category == ContentCategory.SAFE
+        assert confidence > 0.9
+        assert "No policy violations" in reasons[0]
+
+    def test_nsfw_keyword_detection(self):
+        """Test NSFW keyword detection in metadata"""
+        scanner = ContentScanner()
+        category, confidence, reasons = scanner.scan_metadata(
+            title="Adult Content",
+            tags=["nsfw"],
+            description="Explicit material"
+        )
+        assert category == ContentCategory.NSFW
+        assert confidence > 0.9
+        assert any("NSFW" in r for r in reasons)
+
+    def test_violence_keyword_detection(self):
+        """Test violence keyword detection"""
+        scanner = ContentScanner()
+        category, confidence, reasons = scanner.scan_metadata(
+            title="Graphic Violence",
+            tags=["gore", "brutal"]
+        )
+        assert category == ContentCategory.GRAPHIC_VIOLENCE
+        assert confidence > 0.8
+
+    def test_hate_speech_detection(self):
+        """Test hate speech keyword detection"""
+        scanner = ContentScanner()
+        category, confidence, reasons = scanner.scan_metadata(
+            title="Hate Speech Example",
+            tags=["hate"]
+        )
+        assert category == ContentCategory.HATE_SPEECH
+        assert confidence > 0.9
+
+    def test_case_insensitive_scanning(self):
+        """Test that scanning is case-insensitive"""
+        scanner = ContentScanner()
+        category1, _, _ = scanner.scan_metadata(title="NSFW Content")
+        category2, _, _ = scanner.scan_metadata(title="nsfw content")
+        assert category1 == category2 == ContentCategory.NSFW
+
+    def test_visual_content_scanning(self):
+        """Test visual content scanning"""
+        scanner = ContentScanner()
+        category, confidence, reasons = scanner.scan_visual_content(
+            file_path="/path/to/safe.gif",
+            file_hash="a" * 64  # Hash that results in safe content
+        )
+        assert category in [ContentCategory.SAFE, ContentCategory.NSFW, ContentCategory.UNKNOWN]
+        assert 0.0 <= confidence <= 1.0
+        assert len(reasons) > 0
+
+
+class TestModerationPipeline:
+    """Test moderation pipeline"""
+
+    def test_pipeline_init(self):
+        """Test pipeline initialization"""
+        pipeline = ModerationPipeline(
+            strict_mode=True,
+            auto_approve_threshold=0.95,
+            auto_reject_threshold=0.80
+        )
+        assert pipeline.strict_mode is True
+        assert pipeline.auto_approve_threshold == 0.95
+        assert pipeline.auto_reject_threshold == 0.80
+
+    def test_moderate_safe_content(self):
+        """Test moderating safe content"""
+        pipeline = ModerationPipeline()
+        result = pipeline.moderate_content(
+            asset_id="asset123",
+            file_path="/path/to/cat.gif",
+            file_hash="a" * 64,
+            title="Cute Cat",
+            tags=["cat", "funny"],
+            description="A cute cat GIF"
+        )
+        assert isinstance(result, ModerationResult)
+        assert result.decision in [
+            ModerationDecision.APPROVED,
+            ModerationDecision.FLAGGED
+        ]
+        assert result.scan_id
+        assert result.timestamp
+
+    def test_moderate_nsfw_metadata(self):
+        """Test rejection based on NSFW metadata"""
+        pipeline = ModerationPipeline()
+        result = pipeline.moderate_content(
+            asset_id="asset456",
+            file_path="/path/to/content.gif",
+            file_hash="b" * 64,
+            title="NSFW Content",
+            tags=["adult", "explicit"]
+        )
+        assert result.decision == ModerationDecision.REJECTED
+        assert result.category == ContentCategory.NSFW
+        assert len(result.reasons) > 0
+
+    def test_audit_trail_enabled(self):
+        """Test that audit trail is recorded"""
+        pipeline = ModerationPipeline(enable_audit=True)
+        pipeline.moderate_content(
+            asset_id="asset789",
+            file_path="/path/to/test.gif",
+            file_hash="c" * 64,
+            title="Test Content"
+        )
+        audit_trail = pipeline.get_audit_trail()
+        assert len(audit_trail) > 0
+        assert isinstance(audit_trail[0], AuditEntry)
+
+    def test_audit_trail_disabled(self):
+        """Test audit trail can be disabled"""
+        pipeline = ModerationPipeline(enable_audit=False)
+        pipeline.moderate_content(
+            asset_id="asset999",
+            file_path="/path/to/test.gif",
+            file_hash="d" * 64,
+            title="Test Content"
+        )
+        audit_trail = pipeline.get_audit_trail()
+        assert len(audit_trail) == 0
+
+    def test_manual_review(self):
+        """Test manual review workflow"""
+        pipeline = ModerationPipeline()
+
+        # First, auto-moderate content
+        result = pipeline.moderate_content(
+            asset_id="asset321",
+            file_path="/path/to/flagged.gif",
+            file_hash="e" * 64,
+            title="Borderline Content"
+        )
+
+        # Then manually review
+        manual_entry = pipeline.manual_review(
+            asset_id="asset321",
+            scan_id=result.scan_id,
+            decision=ModerationDecision.APPROVED,
+            reviewer_id="moderator123",
+            notes="Reviewed and approved by human moderator"
+        )
+
+        assert isinstance(manual_entry, AuditEntry)
+        assert manual_entry.moderator == "moderator123"
+        assert manual_entry.decision == ModerationDecision.APPROVED
+        assert manual_entry.confidence == 1.0
+
+    def test_get_audit_trail_filtered(self):
+        """Test filtering audit trail by asset"""
+        pipeline = ModerationPipeline()
+
+        pipeline.moderate_content(
+            asset_id="asset_a",
+            file_path="/path/to/a.gif",
+            file_hash="f" * 64,
+            title="Content A"
+        )
+
+        pipeline.moderate_content(
+            asset_id="asset_b",
+            file_path="/path/to/b.gif",
+            file_hash="g" * 64,
+            title="Content B"
+        )
+
+        trail_a = pipeline.get_audit_trail(asset_id="asset_a")
+        assert len(trail_a) > 0
+        assert all(e.asset_id == "asset_a" for e in trail_a)
+
+    def test_get_audit_trail_by_decision(self):
+        """Test filtering audit trail by decision"""
+        pipeline = ModerationPipeline()
+
+        # Moderate safe content
+        pipeline.moderate_content(
+            asset_id="safe_asset",
+            file_path="/path/to/safe.gif",
+            file_hash="h" * 64,
+            title="Safe Content"
+        )
+
+        # Moderate NSFW content
+        pipeline.moderate_content(
+            asset_id="nsfw_asset",
+            file_path="/path/to/nsfw.gif",
+            file_hash="i" * 64,
+            title="NSFW Content",
+            tags=["adult"]
+        )
+
+        rejected = pipeline.get_audit_trail(decision=ModerationDecision.REJECTED)
+        assert all(e.decision == ModerationDecision.REJECTED for e in rejected)
+
+    def test_statistics(self):
+        """Test moderation statistics"""
+        pipeline = ModerationPipeline()
+
+        # Moderate multiple pieces of content
+        for i in range(5):
+            pipeline.moderate_content(
+                asset_id=f"asset_{i}",
+                file_path=f"/path/to/{i}.gif",
+                file_hash=chr(ord('a') + i) * 64,
+                title=f"Content {i}"
+            )
+
+        stats = pipeline.get_statistics()
+        assert "total_scans" in stats
+        assert stats["total_scans"] == 5
+        assert "approval_rate" in stats
+        assert "rejection_rate" in stats
+        assert "flag_rate" in stats
+
+    def test_clear_audit_trail(self):
+        """Test clearing audit trail"""
+        pipeline = ModerationPipeline()
+
+        pipeline.moderate_content(
+            asset_id="temp_asset",
+            file_path="/path/to/temp.gif",
+            file_hash="j" * 64,
+            title="Temp Content"
+        )
+
+        assert len(pipeline.get_audit_trail()) > 0
+
+        pipeline.clear_audit_trail()
+        assert len(pipeline.get_audit_trail()) == 0
+
+    def test_clear_audit_trail_selective(self):
+        """Test clearing audit trail for specific asset"""
+        pipeline = ModerationPipeline()
+
+        pipeline.moderate_content(
+            asset_id="keep_asset",
+            file_path="/path/to/keep.gif",
+            file_hash="k" * 64,
+            title="Keep This"
+        )
+
+        pipeline.moderate_content(
+            asset_id="delete_asset",
+            file_path="/path/to/delete.gif",
+            file_hash="l" * 64,
+            title="Delete This"
+        )
+
+        pipeline.clear_audit_trail(asset_id="delete_asset")
+
+        trail = pipeline.get_audit_trail()
+        assert all(e.asset_id != "delete_asset" for e in trail)
+        assert any(e.asset_id == "keep_asset" for e in trail)
+
+    def test_export_audit_trail(self):
+        """Test exporting audit trail"""
+        pipeline = ModerationPipeline()
+
+        pipeline.moderate_content(
+            asset_id="export_test",
+            file_path="/path/to/export.gif",
+            file_hash="m" * 64,
+            title="Export Test"
+        )
+
+        exported = pipeline.export_audit_trail()
+        assert len(exported) > 0
+        assert isinstance(exported[0], dict)
+        assert "audit_id" in exported[0]
+        assert "asset_id" in exported[0]
+        assert "decision" in exported[0]
+        assert "timestamp" in exported[0]
+
+    def test_scan_id_uniqueness(self):
+        """Test that scan IDs are unique"""
+        pipeline = ModerationPipeline()
+
+        result1 = pipeline.moderate_content(
+            asset_id="asset1",
+            file_path="/path/to/1.gif",
+            file_hash="n" * 64,
+            title="Content 1"
+        )
+
+        time.sleep(0.01)  # Ensure different timestamp
+
+        result2 = pipeline.moderate_content(
+            asset_id="asset2",
+            file_path="/path/to/2.gif",
+            file_hash="o" * 64,
+            title="Content 2"
+        )
+
+        assert result1.scan_id != result2.scan_id
+
+
+class TestModerationDecisions:
+    """Test decision-making logic"""
+
+    def test_auto_approve_high_confidence(self):
+        """Test auto-approval for high confidence safe content"""
+        pipeline = ModerationPipeline(auto_approve_threshold=0.95)
+
+        result = pipeline.moderate_content(
+            asset_id="high_conf_safe",
+            file_path="/path/to/safe.gif",
+            file_hash="a" * 64,  # Hash that results in high confidence safe
+            title="Safe Content"
+        )
+
+        # Should be approved or flagged (depends on hash simulation)
+        assert result.decision in [
+            ModerationDecision.APPROVED,
+            ModerationDecision.FLAGGED
+        ]
+
+    def test_flag_low_confidence(self):
+        """Test flagging for low confidence content"""
+        pipeline = ModerationPipeline(auto_approve_threshold=0.99)
+
+        # Use hash that gives medium confidence
+        result = pipeline.moderate_content(
+            asset_id="medium_conf",
+            file_path="/path/to/medium.gif",
+            file_hash="f" * 8 + "97" + "0" * 54,  # Hash engineered for flagging
+            title="Medium Confidence Content"
+        )
+
+        # Should be flagged for manual review or approved with lower threshold
+        assert result.decision in [
+            ModerationDecision.APPROVED,
+            ModerationDecision.FLAGGED
+        ]
+
+    def test_auto_reject_high_confidence_nsfw(self):
+        """Test auto-rejection for high confidence NSFW"""
+        pipeline = ModerationPipeline(auto_reject_threshold=0.80)
+
+        result = pipeline.moderate_content(
+            asset_id="nsfw_content",
+            file_path="/path/to/nsfw.gif",
+            file_hash="b" * 64,
+            title="Explicit Content",
+            tags=["nsfw", "adult"]
+        )
+
+        assert result.decision == ModerationDecision.REJECTED
+        assert result.category == ContentCategory.NSFW
+
+
+class TestAuditCompliance:
+    """Test audit trail for compliance"""
+
+    def test_audit_contains_required_fields(self):
+        """Test audit entries contain all required fields"""
+        pipeline = ModerationPipeline()
+
+        pipeline.moderate_content(
+            asset_id="compliance_test",
+            file_path="/path/to/test.gif",
+            file_hash="p" * 64,
+            title="Compliance Test"
+        )
+
+        trail = pipeline.get_audit_trail()
+        entry = trail[0]
+
+        assert entry.audit_id
+        assert entry.asset_id
+        assert entry.decision
+        assert entry.category
+        assert isinstance(entry.confidence, float)
+        assert entry.moderator
+        assert entry.timestamp
+        assert isinstance(entry.reasons, list)
+
+    def test_export_time_filtering(self):
+        """Test exporting audit trail with time filters"""
+        pipeline = ModerationPipeline()
+
+        # Create entry
+        pipeline.moderate_content(
+            asset_id="time_test",
+            file_path="/path/to/test.gif",
+            file_hash="q" * 64,
+            title="Time Test"
+        )
+
+        from datetime import datetime, timedelta, timezone
+
+        # Export with future start time should return empty
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        exported = pipeline.export_audit_trail(start_time=future)
+        assert len(exported) == 0
+
+        # Export with past end time should return empty
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        exported = pipeline.export_audit_trail(end_time=past)
+        assert len(exported) == 0
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_empty_metadata(self):
+        """Test moderation with empty metadata"""
+        pipeline = ModerationPipeline()
+
+        result = pipeline.moderate_content(
+            asset_id="empty_meta",
+            file_path="/path/to/content.gif",
+            file_hash="r" * 64,
+            title="",
+            tags=[],
+            description=""
+        )
+
+        assert isinstance(result, ModerationResult)
+        assert result.decision in ModerationDecision
+
+    def test_none_tags(self):
+        """Test moderation with None tags"""
+        pipeline = ModerationPipeline()
+
+        result = pipeline.moderate_content(
+            asset_id="none_tags",
+            file_path="/path/to/content.gif",
+            file_hash="s" * 64,
+            title="Test",
+            tags=None
+        )
+
+        assert isinstance(result, ModerationResult)
+
+    def test_very_long_metadata(self):
+        """Test moderation with very long metadata"""
+        pipeline = ModerationPipeline()
+
+        long_title = "A" * 10000
+        long_tags = [f"tag{i}" for i in range(1000)]
+        long_desc = "B" * 10000
+
+        result = pipeline.moderate_content(
+            asset_id="long_meta",
+            file_path="/path/to/content.gif",
+            file_hash="t" * 64,
+            title=long_title,
+            tags=long_tags,
+            description=long_desc
+        )
+
+        assert isinstance(result, ModerationResult)
+
+    def test_special_characters_metadata(self):
+        """Test metadata with special characters"""
+        pipeline = ModerationPipeline()
+
+        result = pipeline.moderate_content(
+            asset_id="special_chars",
+            file_path="/path/to/content.gif",
+            file_hash="u" * 64,
+            title="Test 中文 🎨 Special",
+            tags=["emoji😀", "unicode中文"],
+            description="Special chars: @#$%^&*()"
+        )
+
+        assert isinstance(result, ModerationResult)
+
+    def test_limit_on_audit_trail(self):
+        """Test limit parameter on get_audit_trail"""
+        pipeline = ModerationPipeline()
+
+        # Create 20 entries
+        for i in range(20):
+            pipeline.moderate_content(
+                asset_id=f"limit_test_{i}",
+                file_path=f"/path/to/{i}.gif",
+                file_hash=chr(ord('a') + (i % 26)) * 64,
+                title=f"Content {i}"
+            )
+
+        # Get only last 5
+        trail = pipeline.get_audit_trail(limit=5)
+        assert len(trail) == 5
+
+    def test_statistics_no_scans(self):
+        """Test statistics when no scans performed"""
+        pipeline = ModerationPipeline()
+        stats = pipeline.get_statistics()
+
+        assert stats["total_scans"] == 0
+        assert stats["approval_rate"] == 0.0
+        assert stats["rejection_rate"] == 0.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_observability.py
+++ b/test_observability.py
@@ -1,0 +1,470 @@
+"""
+Tests for observability module
+"""
+import pytest
+import time
+from observability import (
+    StructuredLogger,
+    MetricsCollector,
+    Tracer,
+    ObservabilityStack,
+    LogLevel,
+    MetricType
+)
+
+
+class TestStructuredLogger:
+    """Test structured logging"""
+
+    def test_basic_logging(self):
+        """Test basic log creation"""
+        logger = StructuredLogger("test-service")
+        logger.info("Test message")
+
+        logs = logger.get_logs()
+        assert len(logs) == 1
+        assert logs[0].message == "Test message"
+        assert logs[0].level == "INFO"
+        assert logs[0].service == "test-service"
+
+    def test_log_levels(self):
+        """Test different log levels"""
+        logger = StructuredLogger("test-service", min_level=LogLevel.DEBUG)
+
+        logger.debug("Debug message")
+        logger.info("Info message")
+        logger.warning("Warning message")
+        logger.error("Error message")
+        logger.critical("Critical message")
+
+        logs = logger.get_logs()
+        assert len(logs) == 5
+        assert logs[0].level == "DEBUG"
+        assert logs[1].level == "INFO"
+        assert logs[2].level == "WARNING"
+        assert logs[3].level == "ERROR"
+        assert logs[4].level == "CRITICAL"
+
+    def test_log_filtering_by_level(self):
+        """Test that logs below min level are filtered"""
+        logger = StructuredLogger("test-service", min_level=LogLevel.WARNING)
+
+        logger.debug("Debug")
+        logger.info("Info")
+        logger.warning("Warning")
+        logger.error("Error")
+
+        logs = logger.get_logs()
+        assert len(logs) == 2
+        assert all(log.level in ["WARNING", "ERROR"] for log in logs)
+
+    def test_log_with_metadata(self):
+        """Test logging with metadata"""
+        logger = StructuredLogger("test-service")
+        logger.info("User action", user_id="user123", action="upload")
+
+        logs = logger.get_logs()
+        assert logs[0].metadata["user_id"] == "user123"
+        assert logs[0].metadata["action"] == "upload"
+
+    def test_log_json_serialization(self):
+        """Test log JSON serialization"""
+        logger = StructuredLogger("test-service")
+        logger.info("Test", key="value")
+
+        logs = logger.get_logs()
+        json_str = logs[0].to_json()
+        assert "Test" in json_str
+        assert "key" in json_str
+        assert "value" in json_str
+
+    def test_clear_logs(self):
+        """Test clearing logs"""
+        logger = StructuredLogger("test-service")
+        logger.info("Message 1")
+        logger.info("Message 2")
+
+        assert len(logger.get_logs()) == 2
+
+        logger.clear_logs()
+        assert len(logger.get_logs()) == 0
+
+
+class TestMetricsCollector:
+    """Test metrics collection"""
+
+    def test_counter_increment(self):
+        """Test counter increments"""
+        collector = MetricsCollector()
+        collector.increment_counter("requests")
+        collector.increment_counter("requests")
+        collector.increment_counter("requests", value=3.0)
+
+        assert collector.get_counter("requests") == 5.0
+
+    def test_counter_with_tags(self):
+        """Test counters with tags"""
+        collector = MetricsCollector()
+        collector.increment_counter("requests", tags={"endpoint": "/api/v1"})
+        collector.increment_counter("requests", tags={"endpoint": "/api/v2"})
+
+        assert collector.get_counter("requests", tags={"endpoint": "/api/v1"}) == 1.0
+        assert collector.get_counter("requests", tags={"endpoint": "/api/v2"}) == 1.0
+
+    def test_gauge_set(self):
+        """Test gauge setting"""
+        collector = MetricsCollector()
+        collector.set_gauge("cpu_usage", 45.5)
+        collector.set_gauge("cpu_usage", 50.2)
+
+        assert collector.get_gauge("cpu_usage") == 50.2
+
+    def test_gauge_with_tags(self):
+        """Test gauges with tags"""
+        collector = MetricsCollector()
+        collector.set_gauge("memory_usage", 1024, tags={"host": "server1"})
+        collector.set_gauge("memory_usage", 2048, tags={"host": "server2"})
+
+        assert collector.get_gauge("memory_usage", tags={"host": "server1"}) == 1024
+        assert collector.get_gauge("memory_usage", tags={"host": "server2"}) == 2048
+
+    def test_histogram_recording(self):
+        """Test histogram value recording"""
+        collector = MetricsCollector()
+        for value in [10, 20, 30, 40, 50]:
+            collector.record_histogram("response_time", value)
+
+        stats = collector.get_histogram_stats("response_time")
+        assert stats["min"] == 10
+        assert stats["max"] == 50
+        assert stats["mean"] == 30
+        assert stats["median"] == 30
+        assert stats["count"] == 5
+
+    def test_histogram_percentiles(self):
+        """Test histogram percentile calculations"""
+        collector = MetricsCollector()
+        values = list(range(1, 101))  # 1 to 100
+        for value in values:
+            collector.record_histogram("latency", value)
+
+        stats = collector.get_histogram_stats("latency")
+        assert stats["p95"] == 95
+        assert stats["p99"] == 99
+
+    def test_timer_context_manager(self):
+        """Test timing operations with context manager"""
+        collector = MetricsCollector()
+
+        with collector.time_operation("db_query"):
+            time.sleep(0.01)  # 10ms
+
+        stats = collector.get_histogram_stats("db_query")
+        assert stats["count"] == 1
+        assert stats["min"] >= 10  # At least 10ms
+
+    def test_get_all_metrics(self):
+        """Test getting all metrics"""
+        collector = MetricsCollector()
+        collector.increment_counter("requests")
+        collector.set_gauge("cpu", 50.0)
+        collector.record_histogram("latency", 100)
+
+        metrics = collector.get_all_metrics()
+        assert len(metrics) == 3
+        assert any(m.name == "requests" for m in metrics)
+        assert any(m.name == "cpu" for m in metrics)
+        assert any(m.name == "latency" for m in metrics)
+
+    def test_clear_metrics(self):
+        """Test clearing metrics"""
+        collector = MetricsCollector()
+        collector.increment_counter("test")
+        collector.set_gauge("test", 1.0)
+
+        collector.clear_metrics()
+        assert collector.get_counter("test") == 0.0
+        assert collector.get_gauge("test") is None
+
+
+class TestTracer:
+    """Test distributed tracing"""
+
+    def test_start_trace(self):
+        """Test starting a new trace"""
+        tracer = Tracer()
+        span = tracer.start_trace("http_request")
+
+        assert span.trace_id is not None
+        assert span.span_id is not None
+        assert span.parent_span_id is None
+        assert span.operation == "http_request"
+        assert span.status == "in_progress"
+
+    def test_start_child_span(self):
+        """Test starting a child span"""
+        tracer = Tracer()
+        root = tracer.start_trace("request")
+        child = tracer.start_span("database_query", root)
+
+        assert child.trace_id == root.trace_id
+        assert child.parent_span_id == root.span_id
+        assert child.span_id != root.span_id
+
+    def test_finish_span(self):
+        """Test finishing a span"""
+        tracer = Tracer()
+        span = tracer.start_trace("operation")
+
+        time.sleep(0.01)
+        tracer.finish_span(span)
+
+        assert span.status == "success"
+        assert span.end_time is not None
+        assert span.duration_ms >= 10
+
+    def test_finish_span_with_error(self):
+        """Test finishing a span with error status"""
+        tracer = Tracer()
+        span = tracer.start_trace("failing_operation")
+        tracer.finish_span(span, status="error")
+
+        assert span.status == "error"
+
+    def test_span_tags(self):
+        """Test span tags"""
+        tracer = Tracer()
+        span = tracer.start_trace("request", tags={"http.method": "POST"})
+
+        assert span.tags["http.method"] == "POST"
+
+    def test_span_logs(self):
+        """Test adding logs to spans"""
+        tracer = Tracer()
+        span = tracer.start_trace("operation")
+        span.add_log("Started processing")
+        span.add_log("Completed step 1", level="DEBUG")
+
+        assert len(span.logs) == 2
+        assert span.logs[0]["message"] == "Started processing"
+
+    def test_get_trace(self):
+        """Test retrieving a complete trace"""
+        tracer = Tracer()
+        root = tracer.start_trace("request")
+        child1 = tracer.start_span("db_query", root)
+        child2 = tracer.start_span("cache_check", root)
+
+        trace = tracer.get_trace(root.trace_id)
+        assert len(trace) == 3
+        assert trace[0].operation == "request"
+
+    def test_multiple_traces(self):
+        """Test managing multiple independent traces"""
+        tracer = Tracer()
+        trace1 = tracer.start_trace("request1")
+        trace2 = tracer.start_trace("request2")
+
+        assert trace1.trace_id != trace2.trace_id
+
+        all_traces = tracer.get_all_traces()
+        assert len(all_traces) == 2
+
+    def test_clear_traces(self):
+        """Test clearing traces"""
+        tracer = Tracer()
+        tracer.start_trace("test")
+
+        tracer.clear_traces()
+        assert len(tracer.get_all_traces()) == 0
+
+
+class TestObservabilityStack:
+    """Test unified observability stack"""
+
+    def test_initialization(self):
+        """Test stack initialization"""
+        obs = ObservabilityStack("my-service")
+
+        assert obs.service_name == "my-service"
+        assert obs.logger is not None
+        assert obs.metrics is not None
+        assert obs.tracer is not None
+
+    def test_start_trace_creates_log_and_metric(self):
+        """Test that starting a trace creates log and metric"""
+        obs = ObservabilityStack("test-service")
+        span = obs.start_trace("operation")
+
+        # Should create a log entry
+        logs = obs.logger.get_logs()
+        assert len(logs) == 1
+        assert "Starting trace" in logs[0].message
+
+        # Should increment counter
+        assert obs.metrics.get_counter("traces.started") == 1.0
+
+    def test_finish_span_creates_log_and_metric(self):
+        """Test that finishing a span creates log and histogram"""
+        obs = ObservabilityStack("test-service")
+        span = obs.start_trace("operation")
+        time.sleep(0.01)
+        obs.finish_span(span)
+
+        # Should create another log entry
+        logs = obs.logger.get_logs()
+        assert len(logs) == 2
+        assert "Finished span" in logs[1].message
+
+        # Should record duration
+        stats = obs.metrics.get_histogram_stats("span.duration")
+        assert stats["count"] == 1
+
+    def test_dashboard_data(self):
+        """Test getting dashboard data"""
+        obs = ObservabilityStack("test-service")
+
+        obs.logger.info("Test message")
+        obs.metrics.increment_counter("requests")
+        obs.metrics.set_gauge("active_connections", 10)
+        span = obs.start_trace("operation")
+        obs.finish_span(span)
+
+        dashboard = obs.get_dashboard_data()
+        assert dashboard["service"] == "test-service"
+        assert "logs" in dashboard
+        assert "metrics" in dashboard
+        assert "traces" in dashboard
+
+    def test_integrated_workflow(self):
+        """Test complete integrated workflow"""
+        obs = ObservabilityStack("api-server")
+
+        # Start a request trace
+        request_span = obs.start_trace("http_request", method="GET", path="/api/users")
+
+        # Log some events
+        obs.logger.info("Received request", method="GET")
+
+        # Record metrics
+        obs.metrics.increment_counter("http.requests", tags={"method": "GET"})
+
+        # Simulate child operations
+        db_span = obs.tracer.start_span("db_query", request_span)
+        time.sleep(0.01)
+        obs.tracer.finish_span(db_span)
+
+        cache_span = obs.tracer.start_span("cache_lookup", request_span)
+        time.sleep(0.005)
+        obs.tracer.finish_span(cache_span)
+
+        # Complete request
+        obs.finish_span(request_span)
+
+        # Verify everything is tracked
+        assert len(obs.logger.get_logs()) >= 2
+        assert obs.metrics.get_counter("http.requests", tags={"method": "GET"}) == 1.0
+        trace = obs.tracer.get_trace(request_span.trace_id)
+        assert len(trace) == 3
+
+
+class TestIntegration:
+    """Test integration scenarios"""
+
+    def test_trace_context_in_logs(self):
+        """Test that trace context is automatically included in logs"""
+        obs = ObservabilityStack("test-service")
+        span = obs.start_trace("operation")
+
+        # Log within trace context
+        obs.logger.info("Processing request")
+
+        logs = obs.logger.get_logs()
+        # Find the processing log
+        processing_log = [l for l in logs if "Processing request" in l.message][0]
+        assert processing_log.trace_id == span.trace_id
+
+    def test_performance_monitoring(self):
+        """Test monitoring performance across multiple operations"""
+        obs = ObservabilityStack("worker-service")
+
+        # Simulate 100 operations with varying durations
+        for i in range(100):
+            span = obs.start_trace(f"job_{i}")
+            time.sleep(0.001 * (i % 10))  # Variable sleep
+            obs.finish_span(span)
+
+        # Check metrics
+        stats = obs.metrics.get_histogram_stats("span.duration")
+        assert stats["count"] == 100
+        assert stats["min"] < stats["max"]
+
+    def test_error_tracking(self):
+        """Test tracking errors through observability"""
+        obs = ObservabilityStack("api-service")
+
+        span = obs.start_trace("failing_request")
+        try:
+            # Simulate error
+            raise ValueError("Something went wrong")
+        except ValueError as e:
+            obs.logger.error("Request failed", error=str(e))
+            obs.finish_span(span, status="error")
+
+        # Verify error is tracked
+        logs = obs.logger.get_logs()
+        error_logs = [l for l in logs if l.level == "ERROR"]
+        assert len(error_logs) == 1
+        assert span.status == "error"
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_empty_histogram_stats(self):
+        """Test getting stats from empty histogram"""
+        collector = MetricsCollector()
+        stats = collector.get_histogram_stats("nonexistent")
+        assert stats == {}
+
+    def test_nonexistent_trace(self):
+        """Test getting nonexistent trace"""
+        tracer = Tracer()
+        trace = tracer.get_trace("fake-trace-id")
+        assert trace == []
+
+    def test_logger_with_none_values(self):
+        """Test logging with None metadata values"""
+        logger = StructuredLogger("test")
+        logger.info("Test", value=None)
+
+        logs = logger.get_logs()
+        assert logs[0].metadata["value"] is None
+
+    def test_metrics_with_zero_value(self):
+        """Test metrics with zero values"""
+        collector = MetricsCollector()
+        collector.increment_counter("zero_counter", value=0.0)
+        collector.set_gauge("zero_gauge", 0.0)
+
+        assert collector.get_counter("zero_counter") == 0.0
+        assert collector.get_gauge("zero_gauge") == 0.0
+
+    def test_span_finished_twice(self):
+        """Test finishing a span multiple times"""
+        tracer = Tracer()
+        span = tracer.start_trace("operation")
+
+        tracer.finish_span(span)
+        first_duration = span.duration_ms
+
+        time.sleep(0.01)
+        tracer.finish_span(span)
+        second_duration = span.duration_ms
+
+        # Duration should be different (span was finished again)
+        assert first_duration != second_duration
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_ratelimit.py
+++ b/test_ratelimit.py
@@ -1,0 +1,550 @@
+"""
+Tests for Rate Limiting Module
+"""
+import pytest
+import time
+from ratelimit import (
+    RateLimiter,
+    RateLimitConfig,
+    RateLimitStrategy,
+    RateLimitError,
+    TokenBucket,
+    FixedWindow,
+    SlidingWindow
+)
+
+
+class TestTokenBucket:
+    """Test token bucket rate limiter"""
+
+    def test_token_bucket_init(self):
+        """Test token bucket initialization"""
+        bucket = TokenBucket(capacity=10, refill_rate=1.0)
+        assert bucket.capacity == 10
+        assert bucket.refill_rate == 1.0
+        assert bucket.tokens == 10.0
+
+    def test_token_bucket_consume_success(self):
+        """Test successful token consumption"""
+        bucket = TokenBucket(capacity=10, refill_rate=1.0)
+        assert bucket.consume(5) is True
+        assert bucket.tokens == 5.0
+
+    def test_token_bucket_consume_failure(self):
+        """Test token consumption when not enough tokens"""
+        bucket = TokenBucket(capacity=10, refill_rate=1.0)
+        bucket.consume(8)
+        assert bucket.consume(5) is False
+        assert bucket.tokens >= 2.0  # May have small refill from elapsed time
+
+    def test_token_bucket_refill(self):
+        """Test token bucket refills over time"""
+        bucket = TokenBucket(capacity=10, refill_rate=10.0)
+        bucket.consume(10)
+        assert bucket.tokens == 0.0
+
+        time.sleep(0.5)
+        bucket._refill()
+        assert bucket.tokens >= 4.0  # Should have refilled ~5 tokens
+
+    def test_token_bucket_get_wait_time(self):
+        """Test wait time calculation"""
+        bucket = TokenBucket(capacity=10, refill_rate=10.0)
+        bucket.consume(10)
+        wait_time = bucket.get_wait_time(5)
+        assert wait_time > 0
+        assert wait_time <= 0.5
+
+    def test_token_bucket_max_capacity(self):
+        """Test bucket doesn't exceed capacity"""
+        bucket = TokenBucket(capacity=10, refill_rate=10.0)
+        time.sleep(2.0)
+        bucket._refill()
+        assert bucket.tokens <= 10.0
+
+
+class TestFixedWindow:
+    """Test fixed window rate limiter"""
+
+    def test_fixed_window_init(self):
+        """Test fixed window initialization"""
+        window = FixedWindow(limit=10, window_seconds=60)
+        assert window.limit == 10
+        assert window.window_seconds == 60
+        assert window.count == 0
+
+    def test_fixed_window_consume_success(self):
+        """Test successful consumption"""
+        window = FixedWindow(limit=10, window_seconds=60)
+        assert window.consume(5) is True
+        assert window.count == 5
+
+    def test_fixed_window_consume_failure(self):
+        """Test consumption when limit exceeded"""
+        window = FixedWindow(limit=10, window_seconds=60)
+        window.consume(8)
+        assert window.consume(5) is False
+        assert window.count == 8
+
+    def test_fixed_window_reset(self):
+        """Test window resets after expiration"""
+        window = FixedWindow(limit=10, window_seconds=1)
+        window.consume(10)
+        assert window.count == 10
+
+        time.sleep(1.1)
+        assert window.consume(5) is True
+        assert window.count == 5
+
+    def test_fixed_window_get_wait_time(self):
+        """Test wait time calculation"""
+        window = FixedWindow(limit=10, window_seconds=60)
+        window.consume(10)
+        wait_time = window.get_wait_time()
+        assert wait_time > 0
+        assert wait_time <= 60
+
+
+class TestSlidingWindow:
+    """Test sliding window rate limiter"""
+
+    def test_sliding_window_init(self):
+        """Test sliding window initialization"""
+        window = SlidingWindow(limit=10, window_seconds=60)
+        assert window.limit == 10
+        assert window.window_seconds == 60
+        assert len(window.timestamps) == 0
+
+    def test_sliding_window_consume_success(self):
+        """Test successful consumption"""
+        window = SlidingWindow(limit=10, window_seconds=60)
+        assert window.consume(5) is True
+        assert len(window.timestamps) == 5
+
+    def test_sliding_window_consume_failure(self):
+        """Test consumption when limit exceeded"""
+        window = SlidingWindow(limit=10, window_seconds=60)
+        window.consume(10)
+        assert window.consume(1) is False
+
+    def test_sliding_window_expiration(self):
+        """Test old requests expire"""
+        window = SlidingWindow(limit=10, window_seconds=1)
+        window.consume(10)
+        assert len(window.timestamps) == 10
+
+        time.sleep(1.1)
+        assert window.consume(5) is True
+        assert len(window.timestamps) == 5
+
+    def test_sliding_window_get_wait_time(self):
+        """Test wait time calculation"""
+        window = SlidingWindow(limit=10, window_seconds=60)
+        window.consume(10)
+        wait_time = window.get_wait_time(1)
+        assert wait_time > 0
+        assert wait_time <= 60
+
+
+class TestRateLimiterTokenBucket:
+    """Test RateLimiter with token bucket strategy"""
+
+    def test_rate_limiter_init(self):
+        """Test rate limiter initialization"""
+        config = RateLimitConfig(
+            requests_per_window=100,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+        assert limiter.config == config
+
+    def test_ip_based_rate_limiting(self):
+        """Test IP-based rate limiting"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Should allow 10 requests
+        for i in range(10):
+            allowed, retry_after = limiter.check_rate_limit(ip_address="192.168.1.1")
+            assert allowed is True
+            assert retry_after is None
+
+        # 11th request should be blocked
+        allowed, retry_after = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is False
+        assert retry_after > 0
+
+    def test_user_based_rate_limiting(self):
+        """Test user-based rate limiting"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Should allow 10 requests
+        for i in range(10):
+            allowed, retry_after = limiter.check_rate_limit(user_id="user123")
+            assert allowed is True
+
+        # 11th request should be blocked
+        allowed, retry_after = limiter.check_rate_limit(user_id="user123")
+        assert allowed is False
+
+    def test_separate_ip_and_user_limits(self):
+        """Test IP and user limits are tracked separately"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up IP quota
+        for i in range(10):
+            limiter.check_rate_limit(ip_address="192.168.1.1")
+
+        # User quota should still be available
+        allowed, _ = limiter.check_rate_limit(user_id="user123")
+        assert allowed is True
+
+    def test_enforce_rate_limit_success(self):
+        """Test enforce_rate_limit allows valid requests"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Should not raise exception
+        limiter.enforce_rate_limit(ip_address="192.168.1.1")
+
+    def test_enforce_rate_limit_failure(self):
+        """Test enforce_rate_limit raises exception when exceeded"""
+        config = RateLimitConfig(
+            requests_per_window=5,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up quota
+        for i in range(5):
+            limiter.enforce_rate_limit(ip_address="192.168.1.1")
+
+        # Should raise exception
+        with pytest.raises(RateLimitError):
+            limiter.enforce_rate_limit(ip_address="192.168.1.1")
+
+    def test_get_remaining_quota(self):
+        """Test getting remaining quota"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        limiter.check_rate_limit(ip_address="192.168.1.1", count=3)
+        quota = limiter.get_remaining_quota(ip_address="192.168.1.1")
+        assert quota['ip'] == 7
+
+    def test_reset_limits(self):
+        """Test resetting rate limits"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up quota
+        for i in range(10):
+            limiter.check_rate_limit(ip_address="192.168.1.1")
+
+        # Reset
+        limiter.reset_limits(ip_address="192.168.1.1")
+
+        # Should be allowed again
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is True
+
+    def test_clear_all(self):
+        """Test clearing all rate limits"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        limiter.check_rate_limit(ip_address="192.168.1.1")
+        limiter.check_rate_limit(user_id="user123")
+
+        limiter.clear_all()
+
+        assert len(limiter._ip_limiters) == 0
+        assert len(limiter._user_limiters) == 0
+
+
+class TestRateLimiterFixedWindow:
+    """Test RateLimiter with fixed window strategy"""
+
+    def test_fixed_window_strategy(self):
+        """Test fixed window strategy"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=1,
+            strategy=RateLimitStrategy.FIXED_WINDOW
+        )
+        limiter = RateLimiter(config)
+
+        # Use up window
+        for i in range(10):
+            allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+            assert allowed is True
+
+        # Should be blocked
+        allowed, retry_after = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is False
+
+        # Wait for window to reset
+        time.sleep(1.1)
+
+        # Should be allowed again
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is True
+
+
+class TestRateLimiterSlidingWindow:
+    """Test RateLimiter with sliding window strategy"""
+
+    def test_sliding_window_strategy(self):
+        """Test sliding window strategy"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=1,
+            strategy=RateLimitStrategy.SLIDING_WINDOW
+        )
+        limiter = RateLimiter(config)
+
+        # Use up window
+        for i in range(10):
+            allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+            assert allowed is True
+
+        # Should be blocked
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is False
+
+        # Wait for window to slide
+        time.sleep(1.1)
+
+        # Should be allowed again
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is True
+
+
+class TestRateLimiterEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_multiple_ips(self):
+        """Test multiple IPs are tracked independently"""
+        config = RateLimitConfig(
+            requests_per_window=5,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up quota for IP1
+        for i in range(5):
+            limiter.check_rate_limit(ip_address="192.168.1.1")
+
+        # IP2 should still have quota
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.2")
+        assert allowed is True
+
+    def test_multiple_users(self):
+        """Test multiple users are tracked independently"""
+        config = RateLimitConfig(
+            requests_per_window=5,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up quota for user1
+        for i in range(5):
+            limiter.check_rate_limit(user_id="user1")
+
+        # User2 should still have quota
+        allowed, _ = limiter.check_rate_limit(user_id="user2")
+        assert allowed is True
+
+    def test_disable_ip_limiting(self):
+        """Test disabling IP-based limiting"""
+        config = RateLimitConfig(
+            requests_per_window=5,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config, enable_per_ip=False)
+
+        # Should not track IP limits
+        for i in range(10):
+            allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+            assert allowed is True
+
+    def test_disable_user_limiting(self):
+        """Test disabling user-based limiting"""
+        config = RateLimitConfig(
+            requests_per_window=5,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config, enable_per_user=False)
+
+        # Should not track user limits
+        for i in range(10):
+            allowed, _ = limiter.check_rate_limit(user_id="user123")
+            assert allowed is True
+
+    def test_count_parameter(self):
+        """Test consuming multiple requests at once"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Consume 5 requests at once
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1", count=5)
+        assert allowed is True
+
+        quota = limiter.get_remaining_quota(ip_address="192.168.1.1")
+        assert quota['ip'] == 5
+
+    def test_both_ip_and_user_limits(self):
+        """Test both IP and user limits enforced"""
+        config = RateLimitConfig(
+            requests_per_window=5,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up IP quota
+        for i in range(5):
+            limiter.check_rate_limit(ip_address="192.168.1.1", user_id="user123")
+
+        # Both IP and user should be blocked
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1", user_id="user456")
+        assert allowed is False
+
+
+class TestRateLimitConfig:
+    """Test rate limit configuration"""
+
+    def test_config_creation(self):
+        """Test creating configuration"""
+        config = RateLimitConfig(
+            requests_per_window=100,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        assert config.requests_per_window == 100
+        assert config.window_seconds == 60
+        assert config.strategy == RateLimitStrategy.TOKEN_BUCKET
+
+    def test_config_default_strategy(self):
+        """Test default strategy is token bucket"""
+        config = RateLimitConfig(
+            requests_per_window=100,
+            window_seconds=60
+        )
+        assert config.strategy == RateLimitStrategy.TOKEN_BUCKET
+
+
+class TestIntegration:
+    """Integration tests for real-world scenarios"""
+
+    def test_api_rate_limiting_scenario(self):
+        """Test realistic API rate limiting"""
+        # 100 requests per minute
+        config = RateLimitConfig(
+            requests_per_window=100,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Simulate 50 API calls
+        for i in range(50):
+            limiter.enforce_rate_limit(
+                ip_address="192.168.1.1",
+                user_id="user123"
+            )
+
+        # Check remaining quota
+        quota = limiter.get_remaining_quota(
+            ip_address="192.168.1.1",
+            user_id="user123"
+        )
+        assert quota['ip'] == 50
+        assert quota['user'] == 50
+
+    def test_burst_protection(self):
+        """Test protection against burst traffic"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=60,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Try burst of 20 requests
+        allowed_count = 0
+        for i in range(20):
+            allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+            if allowed:
+                allowed_count += 1
+
+        # Only 10 should be allowed
+        assert allowed_count == 10
+
+    def test_rate_limit_recovery(self):
+        """Test rate limit recovers over time with token bucket"""
+        config = RateLimitConfig(
+            requests_per_window=10,
+            window_seconds=1,
+            strategy=RateLimitStrategy.TOKEN_BUCKET
+        )
+        limiter = RateLimiter(config)
+
+        # Use up quota
+        for i in range(10):
+            limiter.check_rate_limit(ip_address="192.168.1.1")
+
+        # Should be blocked
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1")
+        assert allowed is False
+
+        # Wait for partial refill
+        time.sleep(0.5)
+
+        # Should have some quota back
+        allowed, _ = limiter.check_rate_limit(ip_address="192.168.1.1", count=3)
+        assert allowed is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test_sharelinks.py
+++ b/test_sharelinks.py
@@ -181,5 +181,305 @@ class TestAssetHash:
             os.unlink(temp_path)
 
 
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_create_asset_hash_empty_file(self):
+        """Test hashing an empty file"""
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            temp_path = f.name
+
+        try:
+            hash_result = create_asset_hash(temp_path)
+            # SHA-256 of empty file is known
+            assert len(hash_result) == 64
+            assert hash_result == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        finally:
+            os.unlink(temp_path)
+
+    def test_create_asset_hash_file_not_found(self):
+        """Test hashing a file that doesn't exist"""
+        with pytest.raises(FileNotFoundError):
+            create_asset_hash("/nonexistent/path/to/file.gif")
+
+    def test_create_asset_hash_large_file(self):
+        """Test hashing a large file (tests chunked reading)"""
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            # Write 10MB of data
+            f.write(b'x' * (10 * 1024 * 1024))
+            temp_path = f.name
+
+        try:
+            hash_result = create_asset_hash(temp_path)
+            assert len(hash_result) == 64
+            assert hash_result.isalnum()
+        finally:
+            os.unlink(temp_path)
+
+    def test_create_asset_hash_binary_data(self):
+        """Test hashing binary GIF-like data"""
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            # GIF header
+            f.write(b'GIF89a\x01\x00\x01\x00\x80\x00\x00')
+            temp_path = f.name
+
+        try:
+            hash_result = create_asset_hash(temp_path)
+            assert len(hash_result) == 64
+        finally:
+            os.unlink(temp_path)
+
+    def test_asset_id_with_special_characters(self):
+        """Test canonical URL with special characters in asset ID"""
+        gen = ShareLinkGenerator()
+        # Test URL-safe characters
+        asset_id = "test-123_ABC.xyz"
+        url = gen.create_canonical_url(asset_id)
+        assert url == "https://gifdist.io/a/test-123_ABC.xyz"
+
+    def test_short_code_character_set(self):
+        """Test that short codes only use alphanumeric characters"""
+        gen = ShareLinkGenerator()
+        for _ in range(50):
+            code = gen.generate_short_code()
+            # Check each character is alphanumeric
+            for char in code:
+                assert char in ShareLinkGenerator.ALPHABET
+
+    def test_empty_title_and_tags(self):
+        """Test creating share link with empty strings and None"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link("asset123", title="", tags=None)
+        link_data = gen._links_db[result["short_code"]]
+        assert link_data["title"] == ""
+        assert link_data["tags"] == []
+
+    def test_empty_tags_list(self):
+        """Test creating share link with empty tags list"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link("asset123", tags=[])
+        link_data = gen._links_db[result["short_code"]]
+        assert link_data["tags"] == []
+
+    def test_very_long_asset_id(self):
+        """Test with very long asset ID"""
+        gen = ShareLinkGenerator()
+        long_id = "a" * 256
+        url = gen.create_canonical_url(long_id)
+        assert url == f"https://gifdist.io/a/{long_id}"
+
+    def test_hash_based_id_short_hash(self):
+        """Test hash-based ID with hash shorter than 16 chars"""
+        gen = ShareLinkGenerator()
+        short_hash = "abc123"
+        asset_id = gen.generate_hash_based_id(short_hash)
+        assert asset_id == "abc123"  # Should return what it can
+
+    def test_created_at_timestamp_format(self):
+        """Test that created_at timestamp is in ISO format"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link("asset999")
+        link_data = gen._links_db[result["short_code"]]
+        created_at = link_data["created_at"]
+        # Should be parseable as ISO format
+        from datetime import datetime
+        parsed_time = datetime.fromisoformat(created_at)
+        assert parsed_time is not None
+
+
+class TestIntegration:
+    """Integration tests for complete workflows"""
+
+    def test_full_asset_workflow(self):
+        """Test complete workflow: hash file -> generate ID -> create share link -> resolve"""
+        # Create test file
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f:
+            f.write(b"Test GIF content")
+            temp_path = f.name
+
+        try:
+            # Step 1: Hash the file
+            content_hash = create_asset_hash(temp_path)
+            assert len(content_hash) == 64
+
+            # Step 2: Generate asset ID from hash
+            gen = ShareLinkGenerator()
+            asset_id = gen.generate_hash_based_id(content_hash)
+            assert len(asset_id) == 16
+
+            # Step 3: Create share link
+            result = gen.create_share_link(
+                asset_id,
+                title="Test GIF",
+                tags=["test"]
+            )
+            assert result["short_code"] is not None
+
+            # Step 4: Resolve the link
+            resolved = gen.resolve_short_link(result["short_code"])
+            assert resolved["asset_id"] == asset_id
+            assert resolved["title"] == "Test GIF"
+            assert resolved["clicks"] == 1
+
+            # Step 5: Get metadata
+            metadata = gen.get_share_metadata(result["short_code"])
+            assert metadata["asset_id"] == asset_id
+            assert metadata["canonical_url"] == f"https://gifdist.io/a/{asset_id}"
+        finally:
+            os.unlink(temp_path)
+
+    def test_duplicate_asset_detection(self):
+        """Test that same content generates same asset ID (deduplication)"""
+        content = b"Identical content"
+
+        # Create two identical files
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f1:
+            f1.write(content)
+            path1 = f1.name
+
+        with tempfile.NamedTemporaryFile(delete=False, mode='wb') as f2:
+            f2.write(content)
+            path2 = f2.name
+
+        try:
+            hash1 = create_asset_hash(path1)
+            hash2 = create_asset_hash(path2)
+
+            # Same content should produce same hash
+            assert hash1 == hash2
+
+            gen = ShareLinkGenerator()
+            id1 = gen.generate_hash_based_id(hash1)
+            id2 = gen.generate_hash_based_id(hash2)
+
+            # Same hash should produce same ID
+            assert id1 == id2
+        finally:
+            os.unlink(path1)
+            os.unlink(path2)
+
+    def test_multiple_share_links_same_asset(self):
+        """Test creating multiple share links for the same asset"""
+        gen = ShareLinkGenerator()
+        asset_id = "shared_asset"
+
+        # Create 3 different share links for same asset
+        link1 = gen.create_share_link(asset_id, title="Link 1")
+        link2 = gen.create_share_link(asset_id, title="Link 2")
+        link3 = gen.create_share_link(asset_id, title="Link 3")
+
+        # All should have different short codes
+        assert link1["short_code"] != link2["short_code"]
+        assert link2["short_code"] != link3["short_code"]
+        assert link1["short_code"] != link3["short_code"]
+
+        # But same canonical URL
+        assert link1["canonical_url"] == link2["canonical_url"]
+        assert link2["canonical_url"] == link3["canonical_url"]
+
+    def test_click_tracking_multiple_links(self):
+        """Test click tracking across multiple share links"""
+        gen = ShareLinkGenerator()
+        link1 = gen.create_share_link("asset1")
+        link2 = gen.create_share_link("asset2")
+
+        # Click link1 twice
+        gen.resolve_short_link(link1["short_code"])
+        gen.resolve_short_link(link1["short_code"])
+
+        # Click link2 once
+        gen.resolve_short_link(link2["short_code"])
+
+        # Verify independent tracking
+        assert gen._links_db[link1["short_code"]]["clicks"] == 2
+        assert gen._links_db[link2["short_code"]]["clicks"] == 1
+
+
+class TestSecurity:
+    """Security-related tests"""
+
+    def test_short_code_entropy(self):
+        """Test that short codes have sufficient entropy"""
+        gen = ShareLinkGenerator()
+        codes = set()
+        iterations = 1000
+
+        for _ in range(iterations):
+            codes.add(gen.generate_short_code())
+
+        # With 62 chars and 8 positions, collision should be extremely rare
+        # Expect 1000 unique codes from 1000 attempts
+        assert len(codes) == iterations
+
+    def test_no_sql_injection_in_asset_id(self):
+        """Test handling of SQL-like strings in asset IDs"""
+        gen = ShareLinkGenerator()
+        malicious_id = "'; DROP TABLE assets; --"
+
+        # Should handle without errors
+        result = gen.create_share_link(malicious_id)
+        assert result["canonical_url"] == f"https://gifdist.io/a/{malicious_id}"
+
+        resolved = gen.resolve_short_link(result["short_code"])
+        assert resolved["asset_id"] == malicious_id
+
+    def test_xss_prevention_in_title(self):
+        """Test that XSS attempts in titles are stored as-is"""
+        gen = ShareLinkGenerator()
+        xss_title = "<script>alert('xss')</script>"
+
+        result = gen.create_share_link("asset123", title=xss_title)
+        metadata = gen.get_share_metadata(result["short_code"])
+
+        # Title should be stored as-is (escaping is frontend's job)
+        assert metadata["title"] == xss_title
+
+    def test_unicode_in_titles_and_tags(self):
+        """Test handling of unicode characters"""
+        gen = ShareLinkGenerator()
+        result = gen.create_share_link(
+            "asset_unicode",
+            title="🎉 Cool GIF 你好",
+            tags=["emoji😀", "中文"]
+        )
+
+        metadata = gen.get_share_metadata(result["short_code"])
+        assert "🎉" in metadata["title"]
+        assert "emoji😀" in metadata["tags"]
+
+
+class TestPerformance:
+    """Performance-related tests"""
+
+    def test_bulk_link_creation(self):
+        """Test creating many links quickly"""
+        gen = ShareLinkGenerator()
+        links = []
+
+        for i in range(100):
+            result = gen.create_share_link(f"asset_{i}")
+            links.append(result["short_code"])
+
+        # Verify all created successfully
+        assert len(links) == 100
+        assert len(set(links)) == 100  # All unique
+
+    def test_bulk_resolution(self):
+        """Test resolving many links quickly"""
+        gen = ShareLinkGenerator()
+        codes = []
+
+        # Create 50 links
+        for i in range(50):
+            result = gen.create_share_link(f"asset_{i}")
+            codes.append(result["short_code"])
+
+        # Resolve all
+        for code in codes:
+            resolved = gen.resolve_short_link(code)
+            assert resolved is not None
+            assert resolved["clicks"] == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test_storage_cdn.py
+++ b/test_storage_cdn.py
@@ -1,0 +1,674 @@
+"""
+Test suite for storage_cdn.py
+Tests object storage, CDN integration, and signed URLs
+"""
+
+import os
+import sys
+import pytest
+import tempfile
+import shutil
+import time
+import hashlib
+import hmac
+import base64
+from pathlib import Path
+from datetime import datetime, timezone
+
+# Import module
+from storage_cdn import (
+    StorageBackend,
+    CachePolicy,
+    StorageConfig,
+    ObjectMetadata,
+    SignedUrlConfig,
+    LocalStorageBackend,
+    SignedUrlGenerator,
+    CDNManager,
+    StorageManager
+)
+
+
+class TestLocalStorageBackend:
+    """Test local filesystem storage backend"""
+
+    @pytest.fixture
+    def backend(self, tmp_path):
+        """Create local storage backend"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="test-bucket",
+            base_path=str(tmp_path / "storage")
+        )
+        return LocalStorageBackend(config)
+
+    def test_put_object(self, backend):
+        """Test storing object"""
+        data = b"Hello, World!"
+        metadata = backend.put_object(
+            "test/file.txt",
+            data,
+            content_type="text/plain",
+            metadata={"user": "test"},
+            cache_control="public, max-age=3600"
+        )
+
+        assert metadata.key == "test/file.txt"
+        assert metadata.size_bytes == len(data)
+        assert metadata.content_type == "text/plain"
+        assert metadata.cache_control == "public, max-age=3600"
+        assert metadata.custom_metadata == {"user": "test"}
+        assert metadata.etag == hashlib.md5(data).hexdigest()
+
+    def test_get_object(self, backend):
+        """Test retrieving object"""
+        original_data = b"Test content"
+        backend.put_object("test.txt", original_data)
+
+        data, metadata = backend.get_object("test.txt")
+
+        assert data == original_data
+        assert metadata.key == "test.txt"
+        assert metadata.size_bytes == len(original_data)
+
+    def test_get_nonexistent_object(self, backend):
+        """Test retrieving non-existent object"""
+        with pytest.raises(FileNotFoundError):
+            backend.get_object("nonexistent.txt")
+
+    def test_delete_object(self, backend):
+        """Test deleting object"""
+        backend.put_object("delete-me.txt", b"data")
+
+        assert backend.object_exists("delete-me.txt")
+        success = backend.delete_object("delete-me.txt")
+        assert success
+        assert not backend.object_exists("delete-me.txt")
+
+    def test_delete_nonexistent_object(self, backend):
+        """Test deleting non-existent object"""
+        success = backend.delete_object("nonexistent.txt")
+        assert not success
+
+    def test_list_objects(self, backend):
+        """Test listing objects"""
+        # Create multiple objects
+        backend.put_object("a/file1.txt", b"data1")
+        backend.put_object("a/file2.txt", b"data2")
+        backend.put_object("b/file3.txt", b"data3")
+
+        # List all
+        objects = backend.list_objects()
+        assert len(objects) == 3
+
+        # List with prefix
+        objects = backend.list_objects(prefix="a/")
+        assert len(objects) == 2
+        assert all(obj.key.startswith("a/") for obj in objects)
+
+    def test_list_objects_max_keys(self, backend):
+        """Test listing objects with max keys limit"""
+        # Create many objects
+        for i in range(10):
+            backend.put_object(f"file{i}.txt", b"data")
+
+        objects = backend.list_objects(max_keys=5)
+        assert len(objects) <= 5
+
+    def test_object_exists(self, backend):
+        """Test checking object existence"""
+        assert not backend.object_exists("test.txt")
+
+        backend.put_object("test.txt", b"data")
+        assert backend.object_exists("test.txt")
+
+    def test_metadata_persistence(self, backend):
+        """Test that metadata persists"""
+        backend.put_object(
+            "meta-test.txt",
+            b"data",
+            content_type="text/plain",
+            metadata={"foo": "bar"},
+            cache_control="public, max-age=3600"
+        )
+
+        data, metadata = backend.get_object("meta-test.txt")
+
+        assert metadata.content_type == "text/plain"
+        assert metadata.custom_metadata == {"foo": "bar"}
+        assert metadata.cache_control == "public, max-age=3600"
+
+    def test_directory_traversal_protection(self, backend):
+        """Test protection against directory traversal"""
+        # Try to store outside base path
+        backend.put_object("../../../etc/passwd", b"malicious")
+
+        # Should be stored safely within base path
+        assert backend.object_exists("../../../etc/passwd")
+        # But not actually outside the base path
+        full_path = backend._get_full_path("../../../etc/passwd")
+        assert backend.base_path in full_path
+
+
+class TestSignedUrlGenerator:
+    """Test signed URL generation and verification"""
+
+    @pytest.fixture
+    def generator(self):
+        """Create URL signer"""
+        return SignedUrlGenerator("test-secret-key")
+
+    def test_generate_signed_url(self, generator):
+        """Test generating signed URL"""
+        url = generator.generate_signed_url(
+            "https://cdn.example.com",
+            "test/file.jpg",
+            SignedUrlConfig(expires_in_seconds=3600)
+        )
+
+        assert "https://cdn.example.com/test%2Ffile.jpg" in url
+        assert "expires=" in url
+        assert "signature=" in url
+
+    def test_verify_signed_url_valid(self, generator):
+        """Test verifying valid signed URL"""
+        expires = int(time.time()) + 3600
+        key = "test/file.jpg"
+
+        # Generate signature manually
+        payload = f"{key}:{expires}"
+        signature = hmac.new(
+            b"test-secret-key",
+            payload.encode(),
+            hashlib.sha256
+        ).digest()
+        sig_b64 = base64.urlsafe_b64encode(signature).decode().rstrip('=')
+
+        # Verify
+        is_valid = generator.verify_signed_url(key, sig_b64, expires)
+        assert is_valid
+
+    def test_verify_signed_url_expired(self, generator):
+        """Test verifying expired URL"""
+        expires = int(time.time()) - 100  # Expired
+        key = "test/file.jpg"
+
+        payload = f"{key}:{expires}"
+        signature = hmac.new(
+            b"test-secret-key",
+            payload.encode(),
+            hashlib.sha256
+        ).digest()
+        sig_b64 = base64.urlsafe_b64encode(signature).decode().rstrip('=')
+
+        is_valid = generator.verify_signed_url(key, sig_b64, expires)
+        assert not is_valid
+
+    def test_verify_signed_url_invalid_signature(self, generator):
+        """Test verifying URL with invalid signature"""
+        expires = int(time.time()) + 3600
+        key = "test/file.jpg"
+
+        # Use wrong signature
+        is_valid = generator.verify_signed_url(key, "invalid-signature", expires)
+        assert not is_valid
+
+    def test_signed_url_with_content_type(self, generator):
+        """Test signed URL with content type"""
+        url = generator.generate_signed_url(
+            "https://cdn.example.com",
+            "test.jpg",
+            SignedUrlConfig(
+                expires_in_seconds=3600,
+                content_type="image/jpeg"
+            )
+        )
+
+        assert "content_type=image%2Fjpeg" in url
+
+    def test_signed_url_with_custom_params(self, generator):
+        """Test signed URL with custom parameters"""
+        url = generator.generate_signed_url(
+            "https://cdn.example.com",
+            "file.txt",
+            SignedUrlConfig(
+                expires_in_seconds=3600,
+                custom_params={"download": "true", "filename": "myfile.txt"}
+            )
+        )
+
+        assert "download=true" in url
+        assert "filename=myfile.txt" in url
+
+
+class TestCDNManager:
+    """Test CDN manager"""
+
+    @pytest.fixture
+    def cdn(self):
+        """Create CDN manager"""
+        return CDNManager("cdn.example.com")
+
+    def test_get_cdn_url_https(self, cdn):
+        """Test getting HTTPS CDN URL"""
+        url = cdn.get_cdn_url("test/file.jpg", use_https=True)
+        assert url == "https://cdn.example.com/test%2Ffile.jpg"
+
+    def test_get_cdn_url_http(self, cdn):
+        """Test getting HTTP CDN URL"""
+        url = cdn.get_cdn_url("test/file.jpg", use_https=False)
+        assert url == "http://cdn.example.com/test%2Ffile.jpg"
+
+    def test_get_cdn_url_without_domain(self):
+        """Test getting CDN URL without domain configured"""
+        cdn = CDNManager(None)
+        with pytest.raises(ValueError):
+            cdn.get_cdn_url("file.jpg")
+
+    def test_get_cache_headers_public(self, cdn):
+        """Test cache headers for public policy"""
+        headers = cdn.get_cache_headers(
+            policy=CachePolicy.PUBLIC,
+            max_age=3600
+        )
+
+        assert "Cache-Control" in headers
+        assert "public" in headers["Cache-Control"]
+        assert "max-age=3600" in headers["Cache-Control"]
+        assert "Expires" in headers
+
+    def test_get_cache_headers_private(self, cdn):
+        """Test cache headers for private policy"""
+        headers = cdn.get_cache_headers(
+            policy=CachePolicy.PRIVATE,
+            max_age=1800
+        )
+
+        assert "private" in headers["Cache-Control"]
+        assert "max-age=1800" in headers["Cache-Control"]
+
+    def test_get_cache_headers_no_cache(self, cdn):
+        """Test cache headers for no-cache policy"""
+        headers = cdn.get_cache_headers(policy=CachePolicy.NO_CACHE)
+
+        assert "no-cache" in headers["Cache-Control"]
+        assert "Expires" not in headers
+
+    def test_get_cache_headers_immutable(self, cdn):
+        """Test cache headers with immutable flag"""
+        headers = cdn.get_cache_headers(
+            policy=CachePolicy.IMMUTABLE,
+            max_age=31536000,
+            immutable=True
+        )
+
+        assert "immutable" in headers["Cache-Control"]
+
+    def test_get_cache_headers_stale_while_revalidate(self, cdn):
+        """Test cache headers with stale-while-revalidate"""
+        headers = cdn.get_cache_headers(
+            policy=CachePolicy.PUBLIC,
+            max_age=3600,
+            stale_while_revalidate=86400
+        )
+
+        assert "stale-while-revalidate=86400" in headers["Cache-Control"]
+
+    def test_invalidate_cache(self, cdn):
+        """Test cache invalidation"""
+        result = cdn.invalidate_cache(["file1.jpg", "file2.jpg"])
+
+        assert "invalidation_id" in result
+        assert result["keys"] == ["file1.jpg", "file2.jpg"]
+        assert result["status"] == "pending"
+
+
+class TestStorageManager:
+    """Test high-level storage manager"""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create storage manager"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="test-bucket",
+            base_path=str(tmp_path / "storage"),
+            cdn_domain="cdn.example.com"
+        )
+        return StorageManager(config, signing_secret="test-secret")
+
+    def test_upload_object(self, manager):
+        """Test uploading object"""
+        data = b"Test data"
+        metadata = manager.upload(
+            "test.txt",
+            data,
+            content_type="text/plain",
+            cache_policy=CachePolicy.PUBLIC,
+            max_age=3600
+        )
+
+        assert metadata.key == "test.txt"
+        assert metadata.size_bytes == len(data)
+        assert metadata.content_type == "text/plain"
+        assert metadata.cdn_url == "https://cdn.example.com/test.txt"
+        assert "public" in metadata.cache_control
+        assert "max-age=3600" in metadata.cache_control
+
+    def test_upload_with_auto_content_type(self, manager):
+        """Test uploading with auto content type detection"""
+        metadata = manager.upload("image.jpg", b"\xFF\xD8\xFF\xE0")
+
+        assert metadata.content_type == "image/jpeg"
+
+    def test_download_object(self, manager):
+        """Test downloading object"""
+        original_data = b"Download test"
+        manager.upload("download.txt", original_data)
+
+        data, metadata = manager.download("download.txt")
+
+        assert data == original_data
+        assert metadata.key == "download.txt"
+
+    def test_delete_object(self, manager):
+        """Test deleting object"""
+        manager.upload("delete.txt", b"data")
+
+        assert manager.exists("delete.txt")
+        success = manager.delete("delete.txt")
+        assert success
+        assert not manager.exists("delete.txt")
+
+    def test_list_objects(self, manager):
+        """Test listing objects"""
+        manager.upload("a/file1.txt", b"data1")
+        manager.upload("a/file2.txt", b"data2")
+        manager.upload("b/file3.txt", b"data3")
+
+        # List all
+        objects = manager.list()
+        assert len(objects) == 3
+        # All should have CDN URLs
+        assert all(obj.cdn_url is not None for obj in objects)
+
+        # List with prefix
+        objects = manager.list(prefix="a/")
+        assert len(objects) == 2
+
+    def test_generate_signed_url(self, manager):
+        """Test generating signed URL"""
+        url = manager.generate_signed_url(
+            "test.jpg",
+            expires_in=3600,
+            content_type="image/jpeg"
+        )
+
+        assert "https://cdn.example.com/test.jpg" in url
+        assert "expires=" in url
+        assert "signature=" in url
+        assert "content_type=image%2Fjpeg" in url
+
+    def test_verify_signed_url(self, manager):
+        """Test verifying signed URL"""
+        # Generate URL
+        url = manager.generate_signed_url("test.jpg", expires_in=3600)
+
+        # Extract parameters (simplified - in real code would parse URL)
+        expires = int(time.time()) + 3600
+
+        # Create correct signature
+        payload = f"test.jpg:{expires}"
+        signature = hmac.new(
+            b"test-secret",
+            payload.encode(),
+            hashlib.sha256
+        ).digest()
+        sig_b64 = base64.urlsafe_b64encode(signature).decode().rstrip('=')
+
+        # Verify
+        is_valid = manager.verify_signed_url("test.jpg", sig_b64, expires)
+        assert is_valid
+
+    def test_get_stats(self, manager):
+        """Test getting storage statistics"""
+        # Upload some files
+        manager.upload("file1.txt", b"data1", content_type="text/plain")
+        manager.upload("file2.txt", b"data2", content_type="text/plain")
+        manager.upload("image.jpg", b"\xFF\xD8\xFF\xE0" * 100, content_type="image/jpeg")
+
+        stats = manager.get_stats()
+
+        assert stats["total_objects"] == 3
+        assert stats["total_size_bytes"] > 0
+        assert stats["backend"] == "local"
+        assert stats["cdn_enabled"] is True
+        assert "text/plain" in stats["by_content_type"]
+        assert stats["by_content_type"]["text/plain"]["count"] == 2
+
+    def test_upload_with_metadata(self, manager):
+        """Test uploading with custom metadata"""
+        metadata_dict = {"user_id": "123", "category": "images"}
+
+        obj_meta = manager.upload(
+            "meta-test.jpg",
+            b"data",
+            metadata=metadata_dict
+        )
+
+        assert obj_meta.custom_metadata == metadata_dict
+
+        # Verify metadata persists
+        data, retrieved_meta = manager.download("meta-test.jpg")
+        assert retrieved_meta.custom_metadata == metadata_dict
+
+
+class TestStorageConfig:
+    """Test storage configuration"""
+
+    def test_config_creation(self):
+        """Test creating storage config"""
+        config = StorageConfig(
+            backend=StorageBackend.S3,
+            bucket_name="my-bucket",
+            region="us-east-1",
+            access_key="key",
+            secret_key="secret",
+            endpoint_url="https://s3.amazonaws.com",
+            cdn_domain="cdn.example.com"
+        )
+
+        assert config.backend == StorageBackend.S3
+        assert config.bucket_name == "my-bucket"
+        assert config.region == "us-east-1"
+        assert config.cdn_domain == "cdn.example.com"
+
+    def test_config_local_backend(self):
+        """Test config for local backend"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="local-bucket",
+            base_path="/tmp/storage"
+        )
+
+        assert config.backend == StorageBackend.LOCAL
+        assert config.base_path == "/tmp/storage"
+
+
+class TestIntegration:
+    """Integration tests"""
+
+    def test_full_workflow(self, tmp_path):
+        """Test complete upload, download, and delete workflow"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="test",
+            base_path=str(tmp_path / "storage"),
+            cdn_domain="cdn.test.com"
+        )
+
+        manager = StorageManager(config, signing_secret="integration-test")
+
+        # Upload
+        original_data = b"Integration test data"
+        upload_meta = manager.upload(
+            "integration/test.txt",
+            original_data,
+            content_type="text/plain",
+            cache_policy=CachePolicy.PUBLIC,
+            max_age=7200,
+            metadata={"test": "integration"}
+        )
+
+        assert upload_meta.cdn_url == "https://cdn.test.com/integration%2Ftest.txt"
+
+        # Download
+        downloaded_data, download_meta = manager.download("integration/test.txt")
+        assert downloaded_data == original_data
+        assert download_meta.custom_metadata == {"test": "integration"}
+
+        # Generate signed URL
+        signed_url = manager.generate_signed_url("integration/test.txt", expires_in=1800)
+        assert "expires=" in signed_url
+        assert "signature=" in signed_url
+
+        # List
+        objects = manager.list(prefix="integration/")
+        assert len(objects) == 1
+        assert objects[0].key == "integration/test.txt"
+
+        # Delete
+        success = manager.delete("integration/test.txt")
+        assert success
+        assert not manager.exists("integration/test.txt")
+
+    def test_multiple_file_operations(self, tmp_path):
+        """Test handling multiple files"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="multi",
+            base_path=str(tmp_path / "multi_storage")
+        )
+
+        manager = StorageManager(config)
+
+        # Upload multiple files
+        files = [
+            ("images/pic1.jpg", b"image1", "image/jpeg"),
+            ("images/pic2.jpg", b"image2", "image/jpeg"),
+            ("docs/file.txt", b"text", "text/plain"),
+            ("videos/clip.mp4", b"video", "video/mp4")
+        ]
+
+        for key, data, content_type in files:
+            manager.upload(key, data, content_type=content_type)
+
+        # List all
+        all_objects = manager.list()
+        assert len(all_objects) == 4
+
+        # List images only
+        images = manager.list(prefix="images/")
+        assert len(images) == 2
+        assert all("images/" in obj.key for obj in images)
+
+        # Get stats
+        stats = manager.get_stats()
+        assert stats["total_objects"] == 4
+        assert "image/jpeg" in stats["by_content_type"]
+        assert stats["by_content_type"]["image/jpeg"]["count"] == 2
+
+    def test_cache_policy_variations(self, tmp_path):
+        """Test different cache policies"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="cache-test",
+            base_path=str(tmp_path / "cache_storage"),
+            cdn_domain="cache.cdn.test"
+        )
+
+        manager = StorageManager(config)
+
+        # Public cache
+        meta1 = manager.upload(
+            "public.jpg",
+            b"data",
+            cache_policy=CachePolicy.PUBLIC,
+            max_age=3600
+        )
+        assert "public" in meta1.cache_control
+        assert "max-age=3600" in meta1.cache_control
+
+        # Private cache
+        meta2 = manager.upload(
+            "private.jpg",
+            b"data",
+            cache_policy=CachePolicy.PRIVATE,
+            max_age=1800
+        )
+        assert "private" in meta2.cache_control
+
+        # No cache
+        meta3 = manager.upload(
+            "no-cache.jpg",
+            b"data",
+            cache_policy=CachePolicy.NO_CACHE
+        )
+        assert "no-cache" in meta3.cache_control
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+
+    def test_empty_file_upload(self, tmp_path):
+        """Test uploading empty file"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="edge",
+            base_path=str(tmp_path / "edge_storage")
+        )
+
+        manager = StorageManager(config)
+        metadata = manager.upload("empty.txt", b"")
+
+        assert metadata.size_bytes == 0
+
+    def test_large_key_name(self, tmp_path):
+        """Test handling large key names"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="edge",
+            base_path=str(tmp_path / "edge_storage")
+        )
+
+        manager = StorageManager(config)
+
+        # Very long key
+        long_key = "a/" * 50 + "file.txt"
+        metadata = manager.upload(long_key, b"data")
+
+        assert metadata.key == long_key
+        assert manager.exists(long_key)
+
+    def test_special_characters_in_key(self, tmp_path):
+        """Test handling special characters in keys"""
+        config = StorageConfig(
+            backend=StorageBackend.LOCAL,
+            bucket_name="special",
+            base_path=str(tmp_path / "special_storage")
+        )
+
+        manager = StorageManager(config)
+
+        # Key with special characters
+        key = "files/test file (copy) #1.txt"
+        metadata = manager.upload(key, b"data")
+
+        assert manager.exists(key)
+        data, meta = manager.download(key)
+        assert data == b"data"
+
+
+if __name__ == '__main__':
+    # Run tests
+    pytest.main([__file__, '-v', '-s'])


### PR DESCRIPTION
## Summary
- Implements comprehensive object storage abstraction layer with CDN integration
- Adds HMAC-SHA256 signed URLs for secure, time-limited access control
- Provides local filesystem backend with metadata persistence (S3/R2 backends ready for future implementation)

## Features
- **Storage Backends**: Abstract interface supporting local, S3, R2, and other backends
- **CDN Integration**: Configurable cache policies (public, private, no-cache, immutable)
- **Signed URLs**: HMAC-SHA256 based secure URL generation with expiration
- **Metadata Management**: Custom metadata storage and retrieval
- **Cache Control**: Full cache header generation (max-age, stale-while-revalidate)
- **CDN Invalidation**: Cache invalidation support for updated content
- **Auto Content-Type**: Automatic MIME type detection
- **Object Listing**: Prefix-based filtering and pagination
- **Storage Stats**: Analytics and statistics tracking

## Test Coverage
- 42 comprehensive tests with 100% pass rate
- Tests cover all major functionality including edge cases
- Local storage backend fully tested
- Signed URL generation and verification tested
- CDN integration and cache policies tested
- Integration tests for complete workflows

## Implementation Details
- `StorageBackend` enum for backend selection
- `LocalStorageBackend` class for filesystem operations
- `SignedUrlGenerator` for secure URL creation
- `CDNManager` for cache control and invalidation
- `StorageManager` high-level API combining all features

## Test Plan
- [x] Run all 42 tests (100% pass rate)
- [x] Test object upload with metadata
- [x] Test object download and retrieval
- [x] Test object deletion
- [x] Test object listing with prefix filtering
- [x] Test signed URL generation and verification
- [x] Test CDN URL generation
- [x] Test cache header generation
- [x] Test storage statistics
- [x] Test edge cases (empty files, special characters, large keys)
- [x] Integration tests for full workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)